### PR TITLE
Only freeze the grade once the student finished the exercise

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -181,7 +181,8 @@ class DragAndDropBlock(XBlock):
 
             # only publish the grade once
             if not self.completed:
-                self.completed = True
+                if self._is_finished():
+                    self.completed = True
                 try:
                     self.runtime.publish(self, 'grade', {
                         'value': len(self.item_state) / float(tot_items) * self.weight,


### PR DESCRIPTION
This is the fix for the bug I spotted before. @dragonfi for review, @antoviaque for merging.

Only freeze the grade once the student finished the exercise, not after the first drop.
