### PR TITLE
Add touch device support

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -85,18 +85,21 @@ class DragAndDropBlock(XBlock):
 
         fragment = Fragment()
         fragment.add_content(render_template('/templates/html/drag_and_drop.html', context))
-        fragment.add_css_url(self.runtime.local_resource_url(self,
-            'public/css/vendor/jquery-ui-1.10.4.custom.min.css'))
-        fragment.add_css_url(self.runtime.local_resource_url(self,
-            'public/css/drag_and_drop.css'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self,
-            'public/js/vendor/jquery-ui-1.10.4.custom.min.js'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self,
-            'public/js/vendor/jquery.html5-placeholder-shim.js'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self,
-            'public/js/vendor/handlebars-v1.1.2.js'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self,
-            'public/js/drag_and_drop.js'))
+        CSS_URLS = (
+            'public/css/vendor/jquery-ui-1.10.4.custom.min.css',
+            'public/css/drag_and_drop.css'
+        )
+        JS_URLS = (
+            'public/js/vendor/jquery-ui-1.10.4.custom.min.js',
+            'public/js/vendor/jquery-ui-touch-punch-0.2.3.min.js',  # Makes it work on touch devices
+            'public/js/vendor/jquery.html5-placeholder-shim.js',
+            'public/js/vendor/handlebars-v1.1.2.js',
+            'public/js/drag_and_drop.js',
+        )
+        for css_url in CSS_URLS:
+            fragment.add_css_url(self.runtime.local_resource_url(self, css_url))
+        for js_url in JS_URLS:
+            fragment.add_javascript_url(self.runtime.local_resource_url(self, js_url))
 
         fragment.initialize_js('DragAndDropBlock')
 

--- a/drag_and_drop_v2/public/js/vendor/jquery-ui-touch-punch-0.2.3.min.js
+++ b/drag_and_drop_v2/public/js/vendor/jquery-ui-touch-punch-0.2.3.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);


### PR DESCRIPTION
This adds touch support, because the dragging and dropping was not working on mobile devices. Uses [jQuery UI Touch Punch](http://touchpunch.furf.com/) to make this work.

I've tested and confirmed it works in:
- Mobile Safari (iOS 8) on iPad with xblock in workbench
- Mobile Safari (iOS 8) on iPad with xblock in LMS
- Desktop Safari 7.1 with xblock in LMS
- Desktop Chrome in LMS and workbench

Note: in order to connect to the devstack from an iPad, I had to modify `lms/envs/devstack.py` on the computer and set `SITE_NAME = '192.168.1.xx:8000'` rather than `SITE_NAME = 'localhost:8000'` - otherwise the XBlock wasn't loading correctly.
