### PR TITLE
Add ability to ask for numerical value on drop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,32 +93,22 @@ You can define an arbitrary number of drag items.
 Testing
 -------
 
-1. In a virtualenv, run
+In a virtualenv, run
 
 ```bash
-$ (cd .../xblock-sdk/; pip install -r requirements.txt)
-$ (cd .../xblock-drag-and-drop-v2/; pip install -r tests/requirements.txt)
+$ cd .../xblock-drag-and-drop-v2/
+$ pip install -r tests/requirements.txt
 ```
 
-2. In the xblock-sdk repository, create the following configuration
-file in `workbench/settings_drag_and_drop_v2.py`
-
-```python
-from settings import *
-
-INSTALLED_APPS += ('drag_and_drop_v2',)
-DATABASES['default']['NAME'] = 'workbench.db'
-```
-
-3. Run this to sync the database before starting the workbench
-(answering no to the superuser question is ok):
+To run the tests, from the xblock-drag-and-drop-v2 repository root:
 
 ```bash
-$ ../xblock-sdk/manage.py syncdb --settings=workbench.settings_drag_and_drop_v2
+$ tests/manage.py test --rednose
 ```
 
-4. To run the tests, from the xblock-drag-and-drop-v2 repository root:
+To include coverage report (although selenium tends to crash with
+segmentation faults when collection test coverage):
 
 ```bash
-$ DJANGO_SETTINGS_MODULE="workbench.settings_drag_and_drop_v2" nosetests --rednose --verbose --with-cover --cover-package=drag_and_drop_v2 --with-django
+$ tests/manage.py test --rednose --with-cover --cover-package=drag_and_drop_v2
 ```

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -65,13 +65,56 @@
     z-index: 10 !important;
     margin-bottom: 5px;
     padding: 10px;
+    opacity: 1;
 }
 
 .xblock--drag-and-drop .drag-container .items .option img {
     max-width: 100%;
 }
 
-.xblock--drag-and-drop .option.fade { opacity: 0.6; }
+.xblock--drag-and-drop .drag-container .items .option .numerical-input {
+    display: none;
+    height: 32px;
+    position: absolute;
+    left: calc(100% + 5px);
+    top: calc(50% - 16px);
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input {
+    display: block;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input .input {
+    display: inline-block;
+    width: 144px;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input .submit-input {
+    box-sizing: border-box;
+    position: absolute;
+    left: 150px;
+    top: 4px;
+    height: 24px;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input.correct .input-submit,
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input.incorrect .input-submit {
+    display: none;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input.correct .input {
+    background: #ceffce;
+    color: #0dad0d;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.within-dropzone .numerical-input.incorrect .input {
+    background: #ffcece;
+    color: #ad0d0d;
+}
+
+.xblock--drag-and-drop .drag-container .items .option.fade {
+    opacity: 0.5;
+}
 
 
 /*** Drop Target ***/

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -207,6 +207,11 @@
     width: 40px;
 }
 
+.xblock--drag-and-drop .items-form .item-numerical-value,
+.xblock--drag-and-drop .items-form .item-numerical-margin {
+    width: 60px;
+}
+
 .xblock--drag-and-drop .items-form textarea {
     width: 97%;
     margin: 0 1%;

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -312,6 +312,11 @@ function DragAndDropEditBlock(runtime, element) {
                                 oldItem.size.height.length - 2);
                             if (ctx.height == 'au') ctx.height = '0';
 
+                            if (oldItem && oldItem.inputOptions) {
+                                ctx.numericalValue = oldItem.inputOptions.value;
+                                ctx.numericalMargin = oldItem.inputOptions.margin;
+                            }
+
                             _fn.build.form.item.count++;
                             $form.append(tpl(ctx));
                             _fn.build.form.item.enableDelete();
@@ -361,7 +366,7 @@ function DragAndDropEditBlock(runtime, element) {
                                 if (width === '0') width = 'auto';
                                 else width = width + 'px';
 
-                                items.push({
+                                var data = {
                                     displayName: name,
                                     zone: $el.find('.zone-select').val(),
                                     id: i,
@@ -374,7 +379,18 @@ function DragAndDropEditBlock(runtime, element) {
                                         height: height
                                     },
                                     backgroundImage: backgroundImage
-                                });
+                                };
+
+                                var numValue = parseFloat($el.find('.item-numerical-value').val());
+                                var numMargin = parseFloat($el.find('.item-numerical-margin').val());
+                                if (isFinite(numValue)) {
+                                    data.inputOptions = {
+                                        value: numValue,
+                                        margin: isFinite(numMargin) ? numMargin : 0
+                                    }
+                                }
+
+                                items.push(data);
                             }
                         });
 

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -2,6 +2,12 @@
     <li class="option" data-value="{{ id }}"
         style="width: {{ size.width }}; height: {{ size.height }}">
         {{{ displayName }}}
+        {{#if inputOptions}}
+          <div class="numerical-input">
+            <input class="input" type="text" />
+            <button class="submit-input">ok</button>
+          </div>
+        {{/if}}
     </li>
 </script>
 
@@ -9,6 +15,10 @@
     <li class="option" data-value="{{ id }}"
         style="width: {{ size.width }}; height: {{ size.height }}">
         <img src="{{ backgroundImage }}" />
+        {{#if inputOptions}}
+          <input class="input" type="text" />
+          <button class="submit-input">ok</button>
+        {{/if}}
     </li>
 </script>
 
@@ -75,6 +85,12 @@
             <input type="text" class="item-width" value="{{ width }}"></input>
             <label>Height (px - 0 for auto)</label>
             <input type="text" class="item-height" value="{{ height }}"></input>
+        </div>
+        <div class="row">
+          <label>Optional numerical value</label>
+          <input type="text" class="item-numerical-value" value="{{ numericalValue }}"></input>
+          <label>Margin ±</label>
+          <input type="text" class="item-numerical-margin" value="{{ numericalMargin }}"></input>
         </div>
     </div>
 </script>

--- a/tests/data/test_data.json
+++ b/tests/data/test_data.json
@@ -46,6 +46,10 @@
       "size": {
         "width": "190px",
         "height": "auto"
+      },
+      "inputOptions": {
+        "value": 100,
+        "margin": 5
       }
     },
     {

--- a/tests/data/test_get_data.json
+++ b/tests/data/test_get_data.json
@@ -27,7 +27,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": false
     },
     {
       "displayName": "B",
@@ -36,7 +37,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": true
     },
     {
       "displayName": "X",
@@ -45,7 +47,8 @@
       "size": {
         "width": "100px",
         "height": "100px"
-      }
+      },
+      "inputOptions": false
     },
     {
       "displayName": "",
@@ -54,7 +57,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": false
     }
   ],
   "state": {

--- a/tests/data/test_get_html_data.json
+++ b/tests/data/test_get_html_data.json
@@ -27,7 +27,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": false
     },
     {
       "displayName": "<i>B</i>",
@@ -36,7 +37,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": true
     },
     {
       "displayName": "X",
@@ -45,7 +47,8 @@
       "size": {
         "width": "100px",
         "height": "100px"
-      }
+      },
+      "inputOptions": false
     },
     {
       "displayName": "",
@@ -54,7 +57,8 @@
       "size": {
         "width": "190px",
         "height": "auto"
-      }
+      },
+      "inputOptions": false
     }
   ],
   "state": {

--- a/tests/data/test_html_data.json
+++ b/tests/data/test_html_data.json
@@ -46,6 +46,10 @@
       "size": {
         "width": "190px",
         "height": "auto"
+      },
+      "inputOptions": {
+        "value": 100,
+        "margin": 5
       }
     },
     {

--- a/tests/integration/data/test_data.json
+++ b/tests/integration/data/test_data.json
@@ -46,6 +46,10 @@
       "size": {
         "width": "190px",
         "height": "auto"
+      },
+      "inputOptions": {
+        "value": 100,
+        "margin": 5
       }
     },
     {

--- a/tests/integration/data/test_html_data.json
+++ b/tests/integration/data/test_html_data.json
@@ -46,6 +46,10 @@
       "size": {
         "width": "190px",
         "height": "auto"
+      },
+      "inputOptions": {
+        "value": 100,
+        "margin": 5
       }
     },
     {

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -1,5 +1,6 @@
 # Imports ###########################################################
 from xml.sax.saxutils import escape
+from selenium.webdriver.support.ui import WebDriverWait
 from tests.utils import load_resource
 
 from workbench import scenarios
@@ -73,3 +74,14 @@ class BaseIntegrationTest(SeleniumTest):
 
     def scroll_to(self, y):
         self.browser.execute_script('window.scrollTo(0, {0})'.format(y))
+
+    def wait_until_contains_html(self, html, elem):
+        wait = WebDriverWait(elem, 2)
+        wait.until(lambda e: html in e.get_attribute('innerHTML'),
+                   u"{} should be in {}".format(html, elem.get_attribute('innerHTML')))
+
+    def wait_until_has_class(self, class_name, elem):
+        wait = WebDriverWait(elem, 2)
+        wait.until(lambda e: class_name in e.get_attribute('class').split(),
+                   u"Class name {} not in {}".format(class_name, elem.get_attribute('class')))
+

--- a/tests/integration/test_custom_data_render.py
+++ b/tests/integration/test_custom_data_render.py
@@ -20,6 +20,7 @@ class TestCustomDataDragAndDropRendering(BaseIntegrationTest):
         items = self._get_items()
 
         self.assertEqual(len(items), 3)
-        self.assertEqual(self.get_element_html(items[0]), "<b>A</b>")
-        self.assertEqual(self.get_element_html(items[1]), "<i>B</i>")
-        self.assertEqual(self.get_element_html(items[2]), '<span style="color:red">X</span>')
+        self.assertIn('<b>A</b>', self.get_element_html(items[0]))
+        self.assertIn('<i>B</i>',  self.get_element_html(items[1]))
+        self.assertIn('<input class="input" type="text">',  self.get_element_html(items[1]))
+        self.assertIn('<span style="color:red">X</span>', self.get_element_html(items[2]))

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Manage.py file for xblock-drag-and-drop-v2"""
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,27 @@
-mock
-nose
-coverage
-rednose
-nose-parameterized
+bok_choy==0.3.2
+cookiecutter==0.7.1
+coverage==3.7.1
+diff-cover==0.7.2
+Django==1.4.16
+django_nose==1.2
+fs==0.5.0
+lazy==1.2
+lxml==3.4.1
+mock==1.0.1
+nose==1.3.4
+nose-parameterized==0.3.5
+pep8==1.5.7
+pylint==0.28
+pypng==0.0.17
+rednose==0.4.1
+requests==2.4.3
+selenium==2.44.0
+simplejson==3.6.5
+webob==1.4
+
+-e git+https://github.com/open-craft/XBlock.git@3ece535ee8e095f21de2f8b28cc720145749f0d6#egg=XBlock
+-e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
+-e git+https://github.com/pmitros/django-pyfs.git@514607d78535fd80bfd23184cd292ee5799b500d#egg=djpyfs
+-e git+https://github.com/open-craft/xblock-sdk.git@39b00c58931664ce29bb4b38df827fe237a69613#egg=xblock-sdk
 
 -e .

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,39 @@
+DEBUG = True
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'workbench',
+    'sample_xblocks.basic',
+    'django_nose',
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'drag_and_drop_v2.db'
+    }
+}
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
+    }
+}
+
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.eggs.Loader',
+)
+
+ROOT_URLCONF = 'urls'
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+STATIC_ROOT = ''
+STATIC_URL = '/static/'
+
+WORKBENCH = {'reset_state_on_restart': False}

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import include, url
+
+urlpatterns = [
+    url(r'^', include('workbench.urls')),
+]


### PR DESCRIPTION
If the input value (with optional margin) is set for a drop item,
an input field is shown and focused when the user drops the item
on the correct zone.

The value is submitted on field blur. If correct (within the margin),
the field is colored green. If the value is not correct, the field is
colored red. In either case, the field gets disabled and user cannot
try again until resetting the exercise.

The exercise is not considered finished until all required input
fields are filled.

If the item has an input set, the user only gets points for the item if
the input value is within the correct margin.
