### PR TITLE
Fix zone deletion.

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -145,7 +145,7 @@ function DragAndDropEditBlock(runtime, element) {
                                 name = 'zone-',
                                 $elements = _fn.build.$el,
                                 num,
-                                obj;
+                                zoneObj;
 
                             if (!oldZone) oldZone = {};
 
@@ -168,7 +168,9 @@ function DragAndDropEditBlock(runtime, element) {
                             _fn.build.form.zone.obj.push(zoneObj);
 
                             // Add fields to zone position form
-                            $elements.zones.form.append(inputTemplate(zoneObj));
+                            $zoneNode = $(inputTemplate(zoneObj));
+                            $zoneNode.data('index', num);
+                            $elements.zones.form.append($zoneNode);
                             _fn.build.form.zone.enableDelete();
 
                             // Add zone div to target
@@ -183,11 +185,20 @@ function DragAndDropEditBlock(runtime, element) {
                         remove: function(e) {
                             var $el = $(e.currentTarget).closest('.zone-row'),
                                 classes = $el.attr('class'),
-                                id = classes.slice(classes.indexOf('zone-row') + 9);
+                                id = classes.slice(classes.indexOf('zone-row') + 9),
+                                index = $el.data('index'),
+                                array_index;
 
                             e.preventDefault();
                             $el.detach();
                             $('#' + id, element).detach();
+
+                            // Find the index of the zone in the array and remove it.
+                            for (array_index = 0; array_index < _fn.build.form.zone.obj.length;
+                                 array_index++) {
+                                if (_fn.build.form.zone.obj[array_index].index == index) break;
+                            }
+                            _fn.build.form.zone.obj.splice(array_index, 1);
 
                             _fn.build.form.zone.formCount--;
                             _fn.build.form.zone.disableDelete();


### PR DESCRIPTION
When deleting a zone, the old version only removed it from the DOM, but not from the underlying data structure that is sent to the server when the save button is pressed.  This resulted in zones not actually being deleted.  This commit fixes this issue.  Also fix a typo in a variable name while we are here.

I have tested this change in a local devstack (which caused more trouble than expected), and it is working fine.  There are some bits of the JS code that aren't quite clear to me -- e.g. the difference between _fn.build.form.zone.count and _fn.build.form.zone.formCount.  Given that the deadline for this issue is tomorrow, I decided against trying to clean up the code any further than necessary.