### PR TITLE
Use numbers instead of letters to identify sample zones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ install:
 script: pep8 drag_and_drop_v2 --max-line-length=120 && python run_tests.py
 notifications:
   email: false
+addons:
+  firefox: "36.0"

--- a/drag_and_drop_v2/default_data.py
+++ b/drag_and_drop_v2/default_data.py
@@ -3,7 +3,7 @@ DEFAULT_DATA = {
     {
       "index": 1,
       "width": 200,
-      "title": "Zone A",
+      "title": "Zone 1",
       "height": 100,
       "x": "120",
       "y": "200",
@@ -12,7 +12,7 @@ DEFAULT_DATA = {
     {
       "index": 2,
       "width": 200,
-      "title": "Zone B",
+      "title": "Zone 2",
       "height": 100,
       "x": "120",
       "y": "360",
@@ -21,12 +21,12 @@ DEFAULT_DATA = {
   ],
   "items": [
     {
-      "displayName": "A",
+      "displayName": "1",
       "feedback": {
-        "incorrect": "No, A does not belong here",
-        "correct": "Yes, it's an A"
+        "incorrect": "No, 1 does not belong here",
+        "correct": "Yes, it's a 1"
       },
-      "zone": "Zone A",
+      "zone": "Zone 1",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -35,12 +35,12 @@ DEFAULT_DATA = {
       }
     },
     {
-      "displayName": "B",
+      "displayName": "2",
       "feedback": {
-        "incorrect": "No, B does not belong here",
-        "correct": "Yes, it's a B"
+        "incorrect": "No, 2 does not belong here",
+        "correct": "Yes, it's a 2"
       },
-      "zone": "Zone B",
+      "zone": "Zone 2",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/install_test_deps.sh
+++ b/install_test_deps.sh
@@ -1,6 +1,6 @@
 # Installs xblock-sdk and dependencies needed to run the tests suite.
 # Run this script inside a fresh virtual environment.
 pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk
-pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements.txt
-pip install -r $VIRTUAL_ENV/src/xblock-sdk/test-requirements.txt
+cd $VIRTUAL_ENV/src/xblock-sdk/ && pip install -r requirements.txt \
+                                && pip install -r test-requirements.txt && cd -
 python setup.py develop

--- a/tests/data/test_data.json
+++ b/tests/data/test_data.json
@@ -3,7 +3,7 @@
     {
       "index": 1,
       "width": 200,
-      "title": "Zone A",
+      "title": "Zone 1",
       "height": 100,
       "y": "200",
       "x": "100",
@@ -12,7 +12,7 @@
     {
       "index": 2,
       "width": 200,
-      "title": "Zone B",
+      "title": "Zone 2",
       "height": 100,
       "y": 0,
       "x": 0,
@@ -21,12 +21,12 @@
   ],
   "items": [
     {
-      "displayName": "A",
+      "displayName": "1",
       "feedback": {
-        "incorrect": "No A",
-        "correct": "Yes A"
+        "incorrect": "No 1",
+        "correct": "Yes 1"
       },
-      "zone": "Zone A",
+      "zone": "Zone 1",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -35,12 +35,12 @@
       }
     },
     {
-      "displayName": "B",
+      "displayName": "2",
       "feedback": {
-        "incorrect": "No B",
-        "correct": "Yes B"
+        "incorrect": "No 2",
+        "correct": "Yes 2"
       },
-      "zone": "Zone B",
+      "zone": "Zone 2",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/data/test_get_data.json
+++ b/tests/data/test_get_data.json
@@ -2,7 +2,7 @@
   "zones": [
     {
       "index": 1,
-      "title": "Zone A",
+      "title": "Zone 1",
       "id": "zone-1",
       "height": 100,
       "y": "200",
@@ -11,7 +11,7 @@
     },
     {
       "index": 2,
-      "title": "Zone B",
+      "title": "Zone 2",
       "id": "zone-2",
       "height": 100,
       "y": 0,
@@ -21,7 +21,7 @@
   ],
   "items": [
     {
-      "displayName": "A",
+      "displayName": "1",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -31,7 +31,7 @@
       "inputOptions": false
     },
     {
-      "displayName": "B",
+      "displayName": "2",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/data/test_get_html_data.json
+++ b/tests/data/test_get_html_data.json
@@ -3,7 +3,7 @@
     {
       "index": 1,
       "width": 200,
-      "title": "Zone <i>A</i>",
+      "title": "Zone <i>1</i>",
       "height": 100,
       "y": "200",
       "x": "100",
@@ -12,7 +12,7 @@
     {
       "index": 2,
       "width": 200,
-      "title": "Zone <b>B</b>",
+      "title": "Zone <b>2</b>",
       "height": 100,
       "y": 0,
       "x": 0,
@@ -21,7 +21,7 @@
   ],
   "items": [
     {
-      "displayName": "<b>A</b>",
+      "displayName": "<b>1</b>",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -31,7 +31,7 @@
       "inputOptions": false
     },
     {
-      "displayName": "<i>B</i>",
+      "displayName": "<i>2</i>",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/data/test_html_data.json
+++ b/tests/data/test_html_data.json
@@ -3,7 +3,7 @@
     {
       "index": 1,
       "width": 200,
-      "title": "Zone <i>A</i>",
+      "title": "Zone <i>1</i>",
       "height": 100,
       "y": "200",
       "x": "100",
@@ -12,7 +12,7 @@
     {
       "index": 2,
       "width": 200,
-      "title": "Zone <b>B</b>",
+      "title": "Zone <b>2</b>",
       "height": 100,
       "y": 0,
       "x": 0,
@@ -21,12 +21,12 @@
   ],
   "items": [
     {
-      "displayName": "<b>A</b>",
+      "displayName": "<b>1</b>",
       "feedback": {
-        "incorrect": "No <b>A</b>",
-        "correct": "Yes <b>A</b>"
+        "incorrect": "No <b>1</b>",
+        "correct": "Yes <b>1</b>"
       },
-      "zone": "Zone <i>A</i>",
+      "zone": "Zone <i>1</i>",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -35,12 +35,12 @@
       }
     },
     {
-      "displayName": "<i>B</i>",
+      "displayName": "<i>2</i>",
       "feedback": {
-        "incorrect": "No <i>B</i>",
-        "correct": "Yes <i>B</i>"
+        "incorrect": "No <i>2</i>",
+        "correct": "Yes <i>2</i>"
       },
-      "zone": "Zone <b>B</b>",
+      "zone": "Zone <b>2</b>",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/integration/data/test_data.json
+++ b/tests/integration/data/test_data.json
@@ -3,7 +3,7 @@
     {
       "index": 1,
       "width": 200,
-      "title": "Zone A",
+      "title": "Zone 1",
       "height": 100,
       "y": "200",
       "x": "100",
@@ -12,7 +12,7 @@
     {
       "index": 2,
       "width": 200,
-      "title": "Zone B",
+      "title": "Zone 2",
       "height": 100,
       "y": 0,
       "x": 0,
@@ -21,12 +21,12 @@
   ],
   "items": [
     {
-      "displayName": "A here",
+      "displayName": "1 here",
       "feedback": {
-        "incorrect": "No A",
-        "correct": "Yes A"
+        "incorrect": "No 1",
+        "correct": "Yes 1"
       },
-      "zone": "Zone A",
+      "zone": "Zone 1",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -35,12 +35,12 @@
       }
     },
     {
-      "displayName": "B here",
+      "displayName": "2 here",
       "feedback": {
-        "incorrect": "No B",
-        "correct": "Yes B"
+        "incorrect": "No 2",
+        "correct": "Yes 2"
       },
-      "zone": "Zone B",
+      "zone": "Zone 2",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/integration/data/test_html_data.json
+++ b/tests/integration/data/test_html_data.json
@@ -3,7 +3,7 @@
     {
       "index": 1,
       "width": 200,
-      "title": "Zone <i>A</i>",
+      "title": "Zone <i>1</i>",
       "height": 100,
       "y": "200",
       "x": "100",
@@ -12,7 +12,7 @@
     {
       "index": 2,
       "width": 200,
-      "title": "Zone <b>B</b>",
+      "title": "Zone <b>2</b>",
       "height": 100,
       "y": 0,
       "x": 0,
@@ -21,12 +21,12 @@
   ],
   "items": [
     {
-      "displayName": "<b>A</b>",
+      "displayName": "<b>1</b>",
       "feedback": {
-        "incorrect": "No <b>A</b>",
-        "correct": "Yes <b>A</b>"
+        "incorrect": "No <b>1</b>",
+        "correct": "Yes <b>1</b>"
       },
-      "zone": "Zone <i>A</i>",
+      "zone": "Zone <i>1</i>",
       "backgroundImage": "",
       "id": 0,
       "size": {
@@ -35,12 +35,12 @@
       }
     },
     {
-      "displayName": "<i>B</i>",
+      "displayName": "<i>2</i>",
       "feedback": {
-        "incorrect": "No <i>B</i>",
-        "correct": "Yes <i>B</i>"
+        "incorrect": "No <i>2</i>",
+        "correct": "Yes <i>2</i>"
       },
-      "zone": "Zone <b>B</b>",
+      "zone": "Zone <b>2</b>",
       "backgroundImage": "",
       "id": 1,
       "size": {

--- a/tests/integration/test_custom_data_render.py
+++ b/tests/integration/test_custom_data_render.py
@@ -20,8 +20,8 @@ class TestCustomDataDragAndDropRendering(BaseIntegrationTest):
         items = self._get_items()
 
         self.assertEqual(len(items), 3)
-        self.assertIn('<b>A</b>', self.get_element_html(items[0]))
-        self.assertIn('<i>B</i>',  self.get_element_html(items[1]))
+        self.assertIn('<b>1</b>', self.get_element_html(items[0]))
+        self.assertIn('<i>2</i>',  self.get_element_html(items[1]))
         self.assertIn('<input class="input" type="text">',  self.get_element_html(items[1]))
         self.assertIn('<span style="color:red">X</span>', self.get_element_html(items[2]))
 

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -20,12 +20,12 @@ class InteractionTestFixture(BaseIntegrationTest):
     PAGE_ID = 'drag_and_drop_v2'
 
     items_map = {
-        0: ItemDefinition(0, 'Zone A', "Yes, it's an A", "No, A does not belong here"),
-        1: ItemDefinition(1, 'Zone B', "Yes, it's a B", "No, B does not belong here"),
+        0: ItemDefinition(0, 'Zone 1', "Yes, it's a 1", "No, 1 does not belong here"),
+        1: ItemDefinition(1, 'Zone 2', "Yes, it's a 2", "No, 2 does not belong here"),
         2: ItemDefinition(2, None, "", "You silly, there are no zones for X")
     }
 
-    all_zones = ['Zone A', 'Zone B']
+    all_zones = ['Zone 1', 'Zone 2']
 
     feedback = {
         "intro": "Intro Feed",
@@ -144,12 +144,12 @@ class InteractionTestFixture(BaseIntegrationTest):
 
 class CustomDataInteractionTest(InteractionTestFixture):
     items_map = {
-        0: ItemDefinition(0, 'Zone A', "Yes A", "No A"),
-        1: ItemDefinition(1, 'Zone B', "Yes B", "No B", "102"),
+        0: ItemDefinition(0, 'Zone 1', "Yes 1", "No 1"),
+        1: ItemDefinition(1, 'Zone 2', "Yes 2", "No 2", "102"),
         2: ItemDefinition(2, None, "", "No Zone for this")
     }
 
-    all_zones = ['Zone A', 'Zone B']
+    all_zones = ['Zone 1', 'Zone 2']
 
     feedback = {
         "intro": "Other Intro Feed",
@@ -162,12 +162,12 @@ class CustomDataInteractionTest(InteractionTestFixture):
 
 class CustomHtmlDataInteractionTest(InteractionTestFixture):
     items_map = {
-        0: ItemDefinition(0, 'Zone <i>A</i>', "Yes <b>A</b>", "No <b>A</b>"),
-        1: ItemDefinition(1, 'Zone <b>B</b>', "Yes <i>B</i>", "No <i>B</i>", "95"),
+        0: ItemDefinition(0, 'Zone <i>1</i>', "Yes <b>1</b>", "No <b>1</b>"),
+        1: ItemDefinition(1, 'Zone <b>2</b>', "Yes <i>2</i>", "No <i>2</i>", "95"),
         2: ItemDefinition(2, None, "", "No Zone for <i>X</i>")
     }
 
-    all_zones = ['Zone <i>A</i>', 'Zone <b>B</b>']
+    all_zones = ['Zone <i>1</i>', 'Zone <b>2</b>']
 
     feedback = {
         "intro": "Intro <i>Feed</i>",

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -29,12 +29,12 @@ class TestDragAndDropRender(BaseIntegrationTest):
         self.assertEqual(len(items), 3)
 
         self.assertEqual(items[0].get_attribute('data-value'), '0')
-        self.assertEqual(items[0].text, 'A')
+        self.assertEqual(items[0].text, '1')
         self.assertIn('ui-draggable', self.get_element_classes(items[0]))
         self._test_style(items[0], {'width': '190px', 'height': 'auto'})
 
         self.assertEqual(items[1].get_attribute('data-value'), '1')
-        self.assertEqual(items[1].text, 'B')
+        self.assertEqual(items[1].text, '2')
         self.assertIn('ui-draggable', self.get_element_classes(items[1]))
         self._test_style(items[1], {'width': '190px', 'height': 'auto'})
 
@@ -48,11 +48,11 @@ class TestDragAndDropRender(BaseIntegrationTest):
 
         self.assertEqual(len(zones), 2)
 
-        self.assertEqual(zones[0].get_attribute('data-zone'), 'Zone A')
+        self.assertEqual(zones[0].get_attribute('data-zone'), 'Zone 1')
         self.assertIn('ui-droppable', self.get_element_classes(zones[0]))
         self._test_style(zones[0], {'top': '200px', 'left': '120px', 'width': '200px', 'height': '100px'})
 
-        self.assertEqual(zones[1].get_attribute('data-zone'), 'Zone B')
+        self.assertEqual(zones[1].get_attribute('data-zone'), 'Zone 2')
         self.assertIn('ui-droppable', self.get_element_classes(zones[1]))
         self._test_style(zones[1], {'top': '360px', 'left': '120px', 'width': '200px', 'height': '100px'})
 

--- a/tests/test_drag_and_drop_v2.py
+++ b/tests/test_drag_and_drop_v2.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import json
 import unittest
@@ -79,8 +78,8 @@ def test_studio_submit():
 class BaseDragAndDropAjaxFixture(object):
     _oldMaxDiff = None
 
-    ZONE_A = None
-    ZONE_B = None
+    ZONE_1 = None
+    ZONE_2 = None
 
     FEEDBACK = {
         0: {"correct": None, "incorrect": None},
@@ -113,10 +112,10 @@ class BaseDragAndDropAjaxFixture(object):
         self._block = None
 
     def initial_data(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def get_data_response(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def test_get_data_returns_expected_data(self):
         expected_response = self.get_data_response()
@@ -124,7 +123,7 @@ class BaseDragAndDropAjaxFixture(object):
         assert_equals(expected_response, get_data_response)
 
     def test_do_attempt_wrong_with_feedback(self):
-        item_id, zone_id = 0, self.ZONE_B
+        item_id, zone_id = 0, self.ZONE_2
         data = json.dumps({"val": item_id, "zone": zone_id, "top": "31px", "left": "216px"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
         assert_equals(res, {
@@ -136,7 +135,7 @@ class BaseDragAndDropAjaxFixture(object):
         })
 
     def test_do_attempt_wrong_without_feedback(self):
-        item_id, zone_id = 2, self.ZONE_A
+        item_id, zone_id = 2, self.ZONE_1
         data = json.dumps({"val": item_id, "zone": zone_id, "top": "42px", "left": "100px"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
         assert_equals(res, {
@@ -148,7 +147,7 @@ class BaseDragAndDropAjaxFixture(object):
         })
 
     def test_do_attempt_correct(self):
-        item_id, zone_id = 0, self.ZONE_A
+        item_id, zone_id = 0, self.ZONE_1
         data = json.dumps({"val": item_id, "zone": zone_id, "top": "11px", "left": "111px"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
         assert_equals(res, {
@@ -160,7 +159,7 @@ class BaseDragAndDropAjaxFixture(object):
         })
 
     def test_do_attempt_with_input(self):
-        data = json.dumps({"val": 1, "zone": self.ZONE_B, "top": "22px", "left": "222px"})
+        data = json.dumps({"val": 1, "zone": self.ZONE_2, "top": "22px", "left": "222px"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
         assert_equals(res, {
             "finished": False,
@@ -226,16 +225,16 @@ class BaseDragAndDropAjaxFixture(object):
         published_grades = []
         def mock_publish(self, event, params):
             if event == 'grade':
-              published_grades.append(params)
+                published_grades.append(params)
         self._block.runtime.publish = mock_publish
 
-        data = json.dumps({"val": 0, "zone": self.ZONE_A, "top": "11px", "left": "111px"})
+        data = json.dumps({"val": 0, "zone": self.ZONE_1, "top": "11px", "left": "111px"})
         self._block.handle('do_attempt', make_request(data))
 
         assert_equals(1, len(published_grades))
         assert_equals({'value': 0.5, 'max_value': 1}, published_grades[-1])
 
-        data = json.dumps({"val": 1, "zone": self.ZONE_B, "top": "22px", "left": "222px"})
+        data = json.dumps({"val": 1, "zone": self.ZONE_2, "top": "22px", "left": "222px"})
         json.loads(self._block.handle('do_attempt', make_request(data)).body)
 
         assert_equals(2, len(published_grades))
@@ -248,7 +247,7 @@ class BaseDragAndDropAjaxFixture(object):
         assert_equals({'value': 1, 'max_value': 1}, published_grades[-1])
 
     def test_do_attempt_final(self):
-        data = json.dumps({"val": 0, "zone": self.ZONE_A, "top": "11px", "left": "111px"})
+        data = json.dumps({"val": 0, "zone": self.ZONE_1, "top": "11px", "left": "111px"})
         self._block.handle('do_attempt', make_request(data))
 
         expected = self.get_data_response()
@@ -262,7 +261,7 @@ class BaseDragAndDropAjaxFixture(object):
         get_data = json.loads(self._block.handle('get_data', Mock()).body)
         assert_equals(expected, get_data)
 
-        data = json.dumps({"val": 1, "zone": self.ZONE_B, "top": "22px", "left": "222px"})
+        data = json.dumps({"val": 1, "zone": self.ZONE_2, "top": "22px", "left": "222px"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
         data = json.dumps({"val": 1, "input": "99"})
         res = json.loads(self._block.handle('do_attempt', make_request(data)).body)
@@ -289,12 +288,12 @@ class BaseDragAndDropAjaxFixture(object):
 
 
 class TestDragAndDropHtmlData(BaseDragAndDropAjaxFixture, unittest.TestCase):
-    ZONE_A = "Zone <i>A</i>"
-    ZONE_B = "Zone <b>B</b>"
+    ZONE_1 = "Zone <i>1</i>"
+    ZONE_2 = "Zone <b>2</b>"
 
     FEEDBACK = {
-        0: {"correct": "Yes <b>A</b>", "incorrect": "No <b>A</b>"},
-        1: {"correct": "Yes <i>B</i>", "incorrect": "No <i>B</i>"},
+        0: {"correct": "Yes <b>1</b>", "incorrect": "No <b>1</b>"},
+        1: {"correct": "Yes <i>2</i>", "incorrect": "No <i>2</i>"},
         2: {"correct": "", "incorrect": ""}
     }
 
@@ -308,12 +307,12 @@ class TestDragAndDropHtmlData(BaseDragAndDropAjaxFixture, unittest.TestCase):
 
 
 class TestDragAndDropPlainData(BaseDragAndDropAjaxFixture, unittest.TestCase):
-    ZONE_A = "Zone A"
-    ZONE_B = "Zone B"
+    ZONE_1 = "Zone 1"
+    ZONE_2 = "Zone 2"
 
     FEEDBACK = {
-        0: {"correct": "Yes A", "incorrect": "No A"},
-        1: {"correct": "Yes B", "incorrect": "No B"},
+        0: {"correct": "Yes 1", "incorrect": "No 1"},
+        1: {"correct": "Yes 2", "incorrect": "No 2"},
         2: {"correct": "", "incorrect": ""}
     }
 
@@ -331,9 +330,9 @@ def test_ajax_solve_and_reset():
     assert_false(block.completed)
     assert_equals(block.item_state, {})
 
-    data = json.dumps({"val":0,"zone":"Zone A","top":"11px","left":"111px"})
+    data = json.dumps({"val":0,"zone":"Zone 1","top":"11px","left":"111px"})
     block.handle('do_attempt', make_request(data))
-    data = json.dumps({"val":1,"zone":"Zone B","top":"22px","left":"222px"})
+    data = json.dumps({"val":1,"zone":"Zone 2","top":"22px","left":"222px"})
     block.handle('do_attempt', make_request(data))
 
     assert_true(block.completed)


### PR DESCRIPTION
Prior to this patch, the sample zones in the default dataset would use letters to identify zones ("Zone A"), but zones added to the default set would use numbers ("Zone 3"). This changes the sample zones to use numbers too.

For consistency and maintainability, the change was also applied to all tests, even when the test would still have worked with the letter format.