### PR TITLE
Fix keyboard help hotkey issues

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -47,9 +47,12 @@ function DragAndDropBlock(runtime, element, configuration) {
             initDroppable();
 
             $(document).on('keydown mousedown touchstart', closePopup);
-            $(document).on('keypress', function(evt) {
-                runOnKey(evt, QUESTION_MARK, showKeyboardHelp);
-            });
+            if (isFirstExercise()) {  // Set up handler for "?" key only once,
+                                      // even if unit contains multiple DnDv2 exercises
+                $(document).on('keypress', function(evt) {
+                    runOnKey(evt, QUESTION_MARK, showKeyboardHelp);
+                });
+            }
             $element.on('click', '.keyboard-help-button', showKeyboardHelp);
             $element.on('keydown', '.keyboard-help-button', function(evt) {
                 runOnKey(evt, RET, showKeyboardHelp);
@@ -65,6 +68,26 @@ function DragAndDropBlock(runtime, element, configuration) {
         }).fail(function() {
             $root.text(gettext("An error occurred. Unable to load drag and drop exercise."));
         });
+    };
+
+    var isFirstExercise = function() {
+        var klass = $element.attr('class');
+        var $block;
+        var siblingSelector;
+
+        if (klass.startsWith('xblock ')) {  // We are in the LMS
+            $block = $element.parent();
+            siblingSelector = '.vert[data-id*="drag-and-drop-v2"]';
+        } else if (klass.startsWith('xblock-v1 ')) {  // We are in the workbench
+            $block = $element;
+            siblingSelector = '.xblock-v1[data-block-type="drag-and-drop-v2"]';
+        }
+
+        var $previousBlocks = $block.prevAll(siblingSelector);
+        if ($previousBlocks.length === 0) {
+            return true;
+        }
+        return false;
     };
 
     var runOnKey = function(evt, key, handler) {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -18,7 +18,6 @@ function DragAndDropBlock(runtime, element, configuration) {
     var SPC = 32;
     var TAB = 9;
     var M = 77;
-    var QUESTION_MARK = 63;
 
     var placementMode = false;
     var $selectedItem;
@@ -47,12 +46,6 @@ function DragAndDropBlock(runtime, element, configuration) {
             initDroppable();
 
             $(document).on('keydown mousedown touchstart', closePopup);
-            if (isFirstExercise()) {  // Set up handler for "?" key only once,
-                                      // even if unit contains multiple DnDv2 exercises
-                $(document).on('keypress', function(evt) {
-                    runOnKey(evt, QUESTION_MARK, showKeyboardHelp);
-                });
-            }
             $element.on('click', '.keyboard-help-button', showKeyboardHelp);
             $element.on('keydown', '.keyboard-help-button', function(evt) {
                 runOnKey(evt, RET, showKeyboardHelp);
@@ -68,26 +61,6 @@ function DragAndDropBlock(runtime, element, configuration) {
         }).fail(function() {
             $root.text(gettext("An error occurred. Unable to load drag and drop exercise."));
         });
-    };
-
-    var isFirstExercise = function() {
-        var klass = $element.attr('class');
-        var $block;
-        var siblingSelector;
-
-        if (klass.startsWith('xblock ')) {  // We are in the LMS
-            $block = $element.parent();
-            siblingSelector = '.vert[data-id*="drag-and-drop-v2"]';
-        } else if (klass.startsWith('xblock-v1 ')) {  // We are in the workbench
-            $block = $element;
-            siblingSelector = '.xblock-v1[data-block-type="drag-and-drop-v2"]';
-        }
-
-        var $previousBlocks = $block.prevAll(siblingSelector);
-        if ($previousBlocks.length === 0) {
-            return true;
-        }
-        return false;
     };
 
     var runOnKey = function(evt, key, handler) {

--- a/drag_and_drop_v2/public/js/view.js
+++ b/drag_and_drop_v2/public/js/view.js
@@ -180,7 +180,6 @@
                                 h('li', gettext('Press "Enter", "Space", "Ctrl-m", or "⌘-m" on an item to select it for dropping, then navigate to the zone you want to drop it on.')),
                                 h('li', gettext('Press "Enter", "Space", "Ctrl-m", or "⌘-m" to drop the item on the current zone.')),
                                 h('li', gettext('Press "Escape" if you want to cancel the drop operation (e.g. because you would like to select a different item).')),
-                                h('li', gettext('Press "?" at any time to bring up this dialog.')),
                             ])
                         ]),
                         h('div.modal-actions', [

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -79,6 +79,9 @@ class BaseIntegrationTest(SeleniumBaseTest):
     def _get_keyboard_help_dialog(self):
         return self._page.find_element_by_css_selector(".keyboard-help .keyboard-help-dialog")
 
+    def _get_keyboard_help_dialogs(self):
+        return self.browser.find_elements_by_css_selector(".keyboard-help .keyboard-help-dialog")
+
     def _get_reset_button(self):
         return self._page.find_element_by_css_selector('.reset-button')
 

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -79,9 +79,6 @@ class BaseIntegrationTest(SeleniumBaseTest):
     def _get_keyboard_help_dialog(self):
         return self._page.find_element_by_css_selector(".keyboard-help .keyboard-help-dialog")
 
-    def _get_keyboard_help_dialogs(self):
-        return self.browser.find_elements_by_css_selector(".keyboard-help .keyboard-help-dialog")
-
     def _get_reset_button(self):
         return self._page.find_element_by_css_selector('.reset-button')
 

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -298,6 +298,16 @@ class InteractionTestBase(object):
         self.assertFalse(dialog_modal_overlay.is_displayed())
         self.assertFalse(dialog_modal.is_displayed())
 
+        if use_keyboard:  # Check if "Keyboard Help" dialog can be dismissed using "ESC"
+            keyboard_help_button.send_keys(Keys.RETURN)
+
+            self.assertTrue(dialog_modal_overlay.is_displayed())
+            self.assertTrue(dialog_modal.is_displayed())
+
+            self._page.send_keys(Keys.ESCAPE)
+
+            self.assertFalse(dialog_modal_overlay.is_displayed())
+            self.assertFalse(dialog_modal.is_displayed())
 
 class BasicInteractionTest(InteractionTestBase):
     """

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -309,6 +309,7 @@ class InteractionTestBase(object):
             self.assertFalse(dialog_modal_overlay.is_displayed())
             self.assertFalse(dialog_modal.is_displayed())
 
+
 class BasicInteractionTest(InteractionTestBase):
     """
     Testing interactions with Drag and Drop XBlock against default data. If default data changes this will break.

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -80,6 +80,14 @@ class InteractionTestBase(object):
         element = self._get_item_by_value(item_value)
         return element.find_element_by_class_name('numerical-input')
 
+    def _get_dialog_components(self, dialog):
+        dialog_modal_overlay = dialog.find_element_by_css_selector('.modal-window-overlay')
+        dialog_modal = dialog.find_element_by_css_selector('.modal-window')
+        return dialog_modal_overlay, dialog_modal
+
+    def _get_dialog_dismiss_button(self, dialog_modal):
+        return dialog_modal.find_element_by_css_selector('.modal-dismiss-button')
+
     def _get_zone_position(self, zone_id):
         return self.browser.execute_script(
             'return $("div[data-zone=\'{zone_id}\']").prevAll(".zone").length'.format(zone_id=zone_id)
@@ -265,12 +273,11 @@ class InteractionTestBase(object):
             self.assertDictEqual(locations_after_reset[item_key], initial_locations[item_key])
             self.assert_reverted_item(item_key)
 
-    def interact_with_keyboard_help(self, scroll_down=250, use_keyboard=False):
+    def interact_with_keyboard_help(self, scroll_down=250, use_keyboard=False, multiple_blocks=False):
         keyboard_help_button = self._get_keyboard_help_button()
         keyboard_help_dialog = self._get_keyboard_help_dialog()
-        dialog_modal_overlay = keyboard_help_dialog.find_element_by_css_selector('.modal-window-overlay')
-        dialog_modal = keyboard_help_dialog.find_element_by_css_selector('.modal-window')
-        dialog_dismiss_button = dialog_modal.find_element_by_css_selector('.modal-dismiss-button')
+        dialog_modal_overlay, dialog_modal = self._get_dialog_components(keyboard_help_dialog)
+        dialog_dismiss_button = self._get_dialog_dismiss_button(dialog_modal)
 
         # Scroll "Keyboard help" button into view to make sure Selenium can successfully click it
         self.scroll_down(pixels=scroll_down)
@@ -291,11 +298,17 @@ class InteractionTestBase(object):
         self.assertFalse(dialog_modal_overlay.is_displayed())
         self.assertFalse(dialog_modal.is_displayed())
 
-        if use_keyboard:  # Try again with "?" key
+        if use_keyboard and not multiple_blocks:  # Try again with "?" key
+                                                  # (behavior for multiple blocks has dedicated test below)
             self._page.send_keys("?")
 
             self.assertTrue(dialog_modal_overlay.is_displayed())
             self.assertTrue(dialog_modal.is_displayed())
+
+            self._page.send_keys(Keys.ESCAPE)
+
+            self.assertFalse(dialog_modal_overlay.is_displayed())
+            self.assertFalse(dialog_modal.is_displayed())
 
 
 class BasicInteractionTest(InteractionTestBase):
@@ -482,3 +495,37 @@ class MultipleBlocksDataInteraction(InteractionTestBase, BaseIntegrationTest):
         self.parameterized_final_feedback_and_reset(self.item_maps['block1'], self.feedback['block1'])
         self._switch_to_block(1)
         self.parameterized_final_feedback_and_reset(self.item_maps['block2'], self.feedback['block2'], scroll_down=900)
+
+    def test_keyboard_help(self):
+        self._switch_to_block(0)
+        # Test mouse and keyboard interaction
+        self.interact_with_keyboard_help()
+        self.interact_with_keyboard_help(use_keyboard=True)
+
+        self._switch_to_block(1)
+        # Test mouse and keyboard interaction
+        self.interact_with_keyboard_help(scroll_down=900)
+        self.interact_with_keyboard_help(scroll_down=0, use_keyboard=True, multiple_blocks=True)
+
+        # When pressing "?" on a page with multiple DnDv2 exercises,
+        # only a single "Keyboard Help" dialog should be shown:
+        first_keyboard_help_dialog, second_keyboard_help_dialog = self._get_keyboard_help_dialogs()
+        first_dialog_modal_overlay, first_dialog_modal = self._get_dialog_components(first_keyboard_help_dialog)
+        first_dialog_dismiss_button = self._get_dialog_dismiss_button(first_dialog_modal)
+        second_dialog_modal_overlay, second_dialog_modal = self._get_dialog_components(second_keyboard_help_dialog)
+
+        self._switch_to_block(0)
+        self._page.send_keys("?")
+        self.assertTrue(first_dialog_modal_overlay.is_displayed())
+        self.assertTrue(first_dialog_modal.is_displayed())
+        self.assertFalse(second_dialog_modal_overlay.is_displayed())
+        self.assertFalse(second_dialog_modal.is_displayed())
+        first_dialog_dismiss_button.click()
+
+        self._switch_to_block(1)
+        self._page.send_keys("?")
+        self.assertTrue(first_dialog_modal_overlay.is_displayed())
+        self.assertTrue(first_dialog_modal.is_displayed())
+        self.assertFalse(second_dialog_modal_overlay.is_displayed())
+        self.assertFalse(second_dialog_modal.is_displayed())
+        first_dialog_dismiss_button.click()

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -80,12 +80,12 @@ class InteractionTestBase(object):
         element = self._get_item_by_value(item_value)
         return element.find_element_by_class_name('numerical-input')
 
-    def _get_dialog_components(self, dialog):
+    def _get_dialog_components(self, dialog):  # pylint: disable=no-self-use
         dialog_modal_overlay = dialog.find_element_by_css_selector('.modal-window-overlay')
         dialog_modal = dialog.find_element_by_css_selector('.modal-window')
         return dialog_modal_overlay, dialog_modal
 
-    def _get_dialog_dismiss_button(self, dialog_modal):
+    def _get_dialog_dismiss_button(self, dialog_modal):  # pylint: disable=no-self-use
         return dialog_modal.find_element_by_css_selector('.modal-dismiss-button')
 
     def _get_zone_position(self, zone_id):
@@ -273,7 +273,7 @@ class InteractionTestBase(object):
             self.assertDictEqual(locations_after_reset[item_key], initial_locations[item_key])
             self.assert_reverted_item(item_key)
 
-    def interact_with_keyboard_help(self, scroll_down=250, use_keyboard=False, multiple_blocks=False):
+    def interact_with_keyboard_help(self, scroll_down=250, use_keyboard=False):
         keyboard_help_button = self._get_keyboard_help_button()
         keyboard_help_dialog = self._get_keyboard_help_dialog()
         dialog_modal_overlay, dialog_modal = self._get_dialog_components(keyboard_help_dialog)
@@ -297,18 +297,6 @@ class InteractionTestBase(object):
 
         self.assertFalse(dialog_modal_overlay.is_displayed())
         self.assertFalse(dialog_modal.is_displayed())
-
-        if use_keyboard and not multiple_blocks:  # Try again with "?" key
-                                                  # (behavior for multiple blocks has dedicated test below)
-            self._page.send_keys("?")
-
-            self.assertTrue(dialog_modal_overlay.is_displayed())
-            self.assertTrue(dialog_modal.is_displayed())
-
-            self._page.send_keys(Keys.ESCAPE)
-
-            self.assertFalse(dialog_modal_overlay.is_displayed())
-            self.assertFalse(dialog_modal.is_displayed())
 
 
 class BasicInteractionTest(InteractionTestBase):
@@ -505,27 +493,4 @@ class MultipleBlocksDataInteraction(InteractionTestBase, BaseIntegrationTest):
         self._switch_to_block(1)
         # Test mouse and keyboard interaction
         self.interact_with_keyboard_help(scroll_down=900)
-        self.interact_with_keyboard_help(scroll_down=0, use_keyboard=True, multiple_blocks=True)
-
-        # When pressing "?" on a page with multiple DnDv2 exercises,
-        # only a single "Keyboard Help" dialog should be shown:
-        first_keyboard_help_dialog, second_keyboard_help_dialog = self._get_keyboard_help_dialogs()
-        first_dialog_modal_overlay, first_dialog_modal = self._get_dialog_components(first_keyboard_help_dialog)
-        first_dialog_dismiss_button = self._get_dialog_dismiss_button(first_dialog_modal)
-        second_dialog_modal_overlay, second_dialog_modal = self._get_dialog_components(second_keyboard_help_dialog)
-
-        self._switch_to_block(0)
-        self._page.send_keys("?")
-        self.assertTrue(first_dialog_modal_overlay.is_displayed())
-        self.assertTrue(first_dialog_modal.is_displayed())
-        self.assertFalse(second_dialog_modal_overlay.is_displayed())
-        self.assertFalse(second_dialog_modal.is_displayed())
-        first_dialog_dismiss_button.click()
-
-        self._switch_to_block(1)
-        self._page.send_keys("?")
-        self.assertTrue(first_dialog_modal_overlay.is_displayed())
-        self.assertTrue(first_dialog_modal.is_displayed())
-        self.assertFalse(second_dialog_modal_overlay.is_displayed())
-        self.assertFalse(second_dialog_modal.is_displayed())
-        first_dialog_dismiss_button.click()
+        self.interact_with_keyboard_help(scroll_down=0, use_keyboard=True)


### PR DESCRIPTION
This PR fixes the following bugs affecting user interaction with DnDv2:

* [x] If multiple DnDv2 blocks are on the same page, pressing hotkey (`?`) brings up multiple dialogs.
* [x] It's almost impossible to enter `?` into any of the text boxes in the block settings in Studio, since it brings up the keyboard help dialog instead.

It also extends existing tests for interacting with the "Keyboard Help" dialog:

* `interact_with_keyboard_help` now checks if dialog can be dismissed by pressing ESC.
* `MultipleBlocksDataInteraction` test now includes a `test_keyboard_help` method which verifies that keyboard help works correctly when multiple DnDv2 blocks are present.

**Test instructions**

1. In the LMS, verify that pressing "?" does *not* bring up the "Keyboard Help" dialog -- we decided to remove this functionality (cf. [this comment](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/50#commitcomment-15478277)).
2. In Studio, try to edit a DnDv2 exercise and enter `?` into a few different input fields. You should be able to do that without the "Keyboard Help" dialog popping up.
3. Lastly, using a unit that includes more than one DnDv2 exercise, check that clicking "Keyboard Help" (in the LMS) does not bring up multiple dialogs.
