### PR TITLE
Expand static image URLs for item background images.

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -152,6 +152,12 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
                 del item['feedback']
                 del item['zone']
                 item['inputOptions'] = 'inputOptions' in item
+                # Fall back on "backgroundImage" to be backward-compatible.
+                image_url = item.get('imageURL') or item.get('backgroundImage')
+                if image_url:
+                    item['expandedImageURL'] = self._expand_static_url(image_url)
+                else:
+                    item['expandedImageURL'] = ''
             return items
 
         return {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -857,7 +857,6 @@ function DragAndDropBlock(runtime, element, configuration) {
                     input.class_name = item_user_state.correct_input ? 'correct' : 'incorrect';
                 }
             }
-            var imageURL = item.imageURL || item.backgroundImage;  // Fall back on "backgroundImage" to be backward-compatible
             var grabbed = false;
             if (item.grabbed !== undefined) {
                 grabbed = item.grabbed;
@@ -870,9 +869,9 @@ function DragAndDropBlock(runtime, element, configuration) {
                 xhr_active: (item_user_state && item_user_state.submitting_location),
                 input: input,
                 displayName: item.displayName,
-                imageURL: imageURL,
+                imageURL: item.expandedImageURL,
                 imageDescription: item.imageDescription,
-                has_image: !!imageURL,
+                has_image: !!item.expandedImageURL,
                 grabbed: grabbed,
                 widthPercent: item.widthPercent, // widthPercent may be undefined (auto width)
                 imgNaturalWidth: item.imgNaturalWidth,

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -35,24 +35,28 @@
         {
           "displayName": "<b>1</b>",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 0,
           "inputOptions": false
         },
         {
           "displayName": "<i>2</i>",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 1,
           "inputOptions": true
         },
         {
           "displayName": "X",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 2,
           "inputOptions": false
         },
         {
           "displayName": "",
           "imageURL": "http://placehold.it/100x300",
+          "expandedImageURL": "http://placehold.it/100x300",
           "id": 3,
           "inputOptions": false
         }

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -35,6 +35,7 @@
         {
           "displayName": "1",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 0,
           "inputOptions": false,
           "size": {"height": "auto", "width": "190px"}
@@ -42,6 +43,7 @@
         {
           "displayName": "2",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 1,
           "inputOptions": true,
           "size": {"height": "auto", "width": "190px"}
@@ -49,6 +51,7 @@
         {
           "displayName": "X",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 2,
           "inputOptions": false,
           "size": {"height": "100px", "width": "100px"}
@@ -56,6 +59,7 @@
         {
           "displayName": "",
           "imageURL": "http://i1.kym-cdn.com/entries/icons/square/000/006/151/tumblr_lltzgnHi5F1qzib3wo1_400.jpg",
+          "expandedImageURL": "http://i1.kym-cdn.com/entries/icons/square/000/006/151/tumblr_lltzgnHi5F1qzib3wo1_400.jpg",
           "id": 3,
           "inputOptions": false,
           "size": {"height": "auto", "width": "190px"}

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -35,24 +35,28 @@
         {
           "displayName": "1",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 0,
           "inputOptions": false
         },
         {
           "displayName": "2",
           "imageURL": "",
+          "expandedImageURL": "",
           "id": 1,
           "inputOptions": true
         },
         {
           "displayName": "X",
-          "imageURL": "",
+          "imageURL": "/static/test_url_expansion",
+          "expandedImageURL": "/course/test-course/assets/test_url_expansion",
           "id": 2,
           "inputOptions": false
         },
         {
           "displayName": "",
           "imageURL": "http://placehold.it/200x100",
+          "expandedImageURL": "http://placehold.it/200x100",
           "id": 3,
           "inputOptions": false
         }

--- a/tests/unit/data/plain/data.json
+++ b/tests/unit/data/plain/data.json
@@ -51,7 +51,7 @@
         "correct": ""
       },
       "zone": "none",
-      "imageURL": "",
+      "imageURL": "/static/test_url_expansion",
       "id": 2
     },
     {

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -45,10 +45,10 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
         self.assertEqual(zones, DEFAULT_DATA["zones"])
         # Items should contain no answer data:
         self.assertEqual(items, [
-            {"id": 0, "displayName": "Goes to the top", "imageURL": "", "inputOptions": False},
-            {"id": 1, "displayName": "Goes to the middle", "imageURL": "", "inputOptions": False},
-            {"id": 2, "displayName": "Goes to the bottom", "imageURL": "", "inputOptions": False},
-            {"id": 3, "displayName": "I don't belong anywhere", "imageURL": "", "inputOptions": False},
+            {"id": i, "displayName": display_name, "imageURL": "", "expandedImageURL": "", "inputOptions": False}
+            for i, display_name in enumerate(
+                ["Goes to the top", "Goes to the middle", "Goes to the bottom", "I don't belong anywhere"]
+            )
         ])
 
     def test_ajax_solve_and_reset(self):


### PR DESCRIPTION
Handle /static/… URLs correctly for item background images, since this is the only portable URL format.

We need to include both the expanded and the unexpanded URLs when passing items to the JS code, since we need the expanded URL for rendering and the original URL for editing in Studio.

**JIRA ticket**: [SOL-1661](https://openedx.atlassian.net/browse/SOL-1661)

**Sandbox**: [LMS](http://master.dndv2.sandbox.opencraft.com/courses/course-v1:TestX+TST-DNDV2-M+now/courseware/1e4f0db6718644ab891d3f57074e0090/042178f28a5a4a0f9a1b7aa93834e59b/) [Studio](http://studio.master.dndv2.sandbox.opencraft.com/container/block-v1:TestX+TST-DNDV2-M+now+type@vertical+block@1e63181ae0c74ef4beae234aa38f7798)

**Testing instructions**: Either use the above sandobx links to a DnDv2 instance configured with background images, or start over with a new unit:

1. Go to Content -> Files & Uploads on your test course in Studio and upload some images.  Keep the tab open to be able to copy the static URLs.
2. In a new browser tab, add a new DnDv2 XBlock to a unit, click "Edit", click "Continue" twice, and enter some image URLs from the previous step (the image descriptions are required as well).
3. Check that the background images display correctly in Studio and the LMS.
4. Change the URLs and check again.