### PR TITLE
Removes role="application"

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -279,7 +279,7 @@ function DragNDropTemplates(url_name) {
                     problemHeader,
                     h('p', {innerHTML: ctx.problem_html}),
                 ]),
-                h('section.drag-container', { attributes: { role: 'application' } }, [
+                h('section.drag-container', {}, [
                     h(
                         'div.item-bank',
                         renderCollection(itemTemplate, items_in_bank, ctx)

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -161,7 +161,7 @@ class TestDragAndDropRender(BaseIntegrationTest):
     def test_drag_container(self):
         self.load_scenario()
         item_bank = self._page.find_element_by_css_selector('.drag-container')
-        self.assertEqual(item_bank.get_attribute('role'), 'application')
+        self.assertIsNone(item_bank.get_attribute('role'))
 
     def test_zones(self):
         self.load_scenario()


### PR DESCRIPTION
Removes role="application" from xblock wrapper and tests.

**Sandbox URL**: 

* Sandbox *with* `role="application"`: http://pr12338.sandbox.opencraft.com/
* Sandbox *without* `role="application"`: http://studio.pr12340.sandbox.opencraft.com/

**Testing instructions**:

1. To run automated tests:

```bash
$ sh install_test_deps.sh
$ python run_tests.py
```

2. Login to the above sandboxes with `staff@example.com`/`edx`, and visit course named "Testing DnDv2 Accessibility".  
    Each unit contains an DnDv2 xblock, which you can test with screen readers.  

    For example, the triangle background image uses the alt text "An isosceles triangle with three layers of similar height. It is shown upright, so the widest layer is located at the bottom, and the narrowest layer is located at the top.".

**Author Notes and Concerns**

I was not able to reproduce the accessibility issue noted in SOL-1770 on any of the screen readers I tried.  I tested the Dndv2 XBlock both before and after removing the `role="application"` attribute, and got the same result for both code sets.

These screen readers successfully read all the text on the page, including instructions and image alt tags:

* [VoiceOver](https://www.apple.com/voiceover/info/guide/_1124.html): Mac, built in tool
* [Narrator](http://windows.microsoft.com/en-au/windows-10/getstarted-hear-text-read-aloud): Windows 10, built-in tool
* [TalkBack](https://support.google.com/accessibility/android/answer/6007100): Android

The screen readers below had their own idiosyncracies, but showed no difference in behaviour between the two code sets:

* [JAWS](http://www.freedomscientific.com/Products/Blindness/JAWS) - couldn't get it to read any of the text on the page, except for elements I could tab to. Maybe because I only had the free trial version?
* [NVDA](http://www.nvaccess.org/) - successfully reads any text or image alt text I can mouse over, but doesn't just read out the page.

**Reviewers**
- [ ] @itsjeyd 
- [ ] @cptvitamin