### PR TITLE
Adding usability for keyboard controls (SOL-1807)

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -116,10 +116,10 @@ function DragAndDropTemplates(configuration) {
             itemSpinnerTemplate(item)
         ];
         var item_content = itemContentTemplate(item);
+        // Insert information about zone in which this item has been placed
+        var item_description_id = configuration.url_name + '-item-' + item.value + '-description';
+        item_content.properties.attributes = { 'aria-describedby': item_description_id };
         if (item.is_placed) {
-            // Insert information about zone in which this item has been placed
-            var item_description_id = configuration.url_name + '-item-' + item.value + '-description';
-            item_content.properties.attributes = { 'aria-describedby': item_description_id };
             var zone_title = (zone.title || "Unknown Zone");  // This "Unknown" text should never be seen, so does not need i18n
             var description_content;
             if (configuration.mode === DragAndDropBlock.ASSESSMENT_MODE) {
@@ -135,8 +135,14 @@ function DragAndDropTemplates(configuration) {
                 { key: item.value + '-description', id: item_description_id, className: 'sr' },
                 description_content
             );
-            children.splice(1, 0, item_description);
+        } else {
+            var item_description = h(
+              'div',
+              { id: item_description_id, className: 'sr'},
+              gettext('Press "Enter", "Space", "Ctrl-m", or "⌘-m" on an item to select it for dropping, then navigate to the zone you want to drop it on.')
+            );
         }
+        children.splice(1, 0, item_description);
         children.splice(1, 0, item_content);
         return (
             h(
@@ -190,13 +196,28 @@ function DragAndDropTemplates(configuration) {
         // If zone is aligned, mark its item alignment
         // and render its placed items as children
         var item_wrapper = 'div.item-wrapper';
-        var items_in_zone = [];
-        if (zone.align !== 'none') {
-            item_wrapper += '.item-align.item-align-' + zone.align;
-            var is_item_in_zone = function(i) { return i.is_placed && (i.zone === zone.uid); };
-            items_in_zone = $.grep(ctx.items, is_item_in_zone);
+        var is_item_in_zone = function(i) { return i.is_placed && (i.zone === zone.uid); };
+        var items_in_zone = $.grep(ctx.items, is_item_in_zone);
+        var zone_description_id = 'zone-' + zone.id + '-description';
+        if (items_in_zone.length == 0) {
+          var zone_description = h(
+            'div',
+            { id: zone_description_id, className: 'sr'},
+            gettext("No items placed here")
+          );
+        } else {
+          var zone_description = h(
+            'div',
+            { id: zone_description_id, className: 'sr'},
+            gettext('Items placed here: ') + items_in_zone.map(function (item) { return item.displayName; }).join(", ")
+          );
         }
-
+        if (zone.align !== 'none') {
+          item_wrapper += '.item-align.item-align-' + zone.align;
+          //items_in_zone = $.grep(ctx.items, is_item_in_zone);
+        } else {
+          items_in_zone = [];
+        }
         return (
             h(
                 selector,
@@ -211,6 +232,7 @@ function DragAndDropTemplates(configuration) {
                         'data-zone_id': zone.id,
                         'data-zone_align': zone.align,
                         'role': 'button',
+                        'aria-describedby': zone_description_id,
                     },
                     style: {
                         top: zone.y_percent + '%', left: zone.x_percent + "%",
@@ -220,7 +242,8 @@ function DragAndDropTemplates(configuration) {
                 [
                     h('p', { className: className }, zone.title),
                     h('p', { className: 'zone-description sr' }, zone.description),
-                    h(item_wrapper, renderCollection(itemTemplate, items_in_zone, ctx))
+                    h(item_wrapper, renderCollection(itemTemplate, items_in_zone, ctx)),
+                    zone_description
                 ]
             )
         );

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -150,7 +150,8 @@ class TestDragAndDropRender(BaseIntegrationTest):
             try:
                 background_image = item.find_element_by_css_selector('img')
             except NoSuchElementException:
-                self.assertEqual(item.text, self.ITEM_PROPERTIES[index]['text'])
+                item_content = item.find_element_by_css_selector('.item-content')
+                self.assertEqual(item_content.text, self.ITEM_PROPERTIES[index]['text'])
             else:
                 self.assertEqual(
                     background_image.get_attribute('alt'),


### PR DESCRIPTION
Edit: this pull request is covered by the OpenCraft contributor agreement. @antoviaque 

This should add in the following functionality:

1. 'When tabbing through the focusable controls, the Windows user is never exposed to the alt text for the background image, which is critical to understanding the context of the problem. I think a reasonable solution would be to add an ID to this element and then reference it via aria-describedby on all the dropzones. The screen reader user would move focus to the dropzone, hear its description, and then hear the description of its meaning in the greater context of the problem.'

2. 'In certain screen readers, the keyboard controls are not exposed. On Windows and NVDA< only the CTRL + M keycombo works to drag and drop the items (many users will not be aware of this combination). It would be very cool to add an additional aria-describedby that references that bit of help text that is available in the Keyboard help modal: "Press "Enter", "Space", "Ctrl-m", or "⌘-m" on an item to select it for dropping, then navigate to the zone you want to drop it on." on the draggable items and "Press "Enter", "Space", "Ctrl-m", or "⌘-m" to drop the item on the current zone." on the dropzones.'

3. 'when I went to a dropzone that had an item in it, it was not read back to me, so I had no idea if a dropzone had any items in it or not.'

**Sandbox URLs**

Studio: http://studio-dndv2-sandbox7.opencraft.hosting/
LMS: http://dndv2-sandbox7.opencraft.hosting/

The sandbox is at version de47111bb93a892778fa32fb35d5d6ee851be293