### PR TITLE
Keep items in dropped position in assessment mode.

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -190,6 +190,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
             return items
 
         return {
+            "mode": self.mode,
             "zones": self._get_zones(),
             # SDK doesn't supply url_name.
             "url_name": getattr(self, 'url_name', ''),
@@ -337,12 +338,18 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
             'is_correct': is_correct,
         })
 
-        return {
-            'correct': is_correct,
-            'finished': self._is_finished(),
-            'overall_feedback': overall_feedback,
-            'feedback': feedback
-        }
+        if self.mode == self.ASSESSMENT_MODE:
+            # In assessment mode we don't send any feedback on drop.
+            result = {}
+        else:
+            result = {
+                'correct': is_correct,
+                'finished': self._is_finished(),
+                'overall_feedback': overall_feedback,
+                'feedback': feedback
+            }
+
+        return result
 
     @XBlock.json_handler
     def reset(self, data, suffix=''):

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -409,6 +409,10 @@ msgid "ok"
 msgstr ""
 
 #: public/js/drag_and_drop.js
+msgid "Placed in: "
+msgstr ""
+
+#: public/js/drag_and_drop.js
 msgid "Correctly placed in: "
 msgstr ""
 

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -494,6 +494,10 @@ msgid "ok"
 msgstr "ök Ⱡ'σя#"
 
 #: public/js/drag_and_drop.js
+msgid "Placed in: "
+msgstr "Pläçéd ïn:  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+
+#: public/js/drag_and_drop.js
 msgid "Correctly placed in: "
 msgstr "Çörréçtlý pläçéd ïn:  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -1,5 +1,6 @@
 {
     "title": "DnDv2 XBlock with HTML instructions",
+    "mode": "standard",
     "show_title": false,
     "problem_text": "Solve this <strong>drag-and-drop</strong> problem.",
     "show_problem_header": false,

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -1,5 +1,6 @@
 {
     "title": "Drag and Drop",
+    "mode": "standard",
     "show_title": true,
     "problem_text": "",
     "show_problem_header": true,

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -1,5 +1,6 @@
 {
     "title": "DnDv2 XBlock with plain text instructions",
+    "mode": "standard",
     "show_title": true,
     "problem_text": "Can you solve this drag-and-drop problem?",
     "show_problem_header": true,

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -5,6 +5,8 @@ import unittest
 
 from xblockutils.resources import ResourceLoader
 
+from drag_and_drop_v2.drag_and_drop_v2 import DragAndDropBlock
+
 from ..utils import make_block, TestCaseMixin
 
 
@@ -89,6 +91,14 @@ class BaseDragAndDropAjaxFixture(TestCaseMixin):
             "correct": True,
             "feedback": self.FEEDBACK[item_id]["correct"]
         })
+
+    def test_do_attempt_in_assessment_mode(self):
+        self.block.mode = DragAndDropBlock.ASSESSMENT_MODE
+        item_id, zone_id = 0, self.ZONE_1
+        data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
+        res = self.call_handler('do_attempt', data)
+        # In assessment mode, the do_attempt doesn't return any data.
+        self.assertEqual(res, {})
 
     def test_grading(self):
         published_grades = []

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -30,6 +30,7 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
         zones = config.pop("zones")
         items = config.pop("items")
         self.assertEqual(config, {
+            "mode": DragAndDropBlock.STANDARD_MODE,
             "display_zone_borders": False,
             "display_zone_labels": False,
             "title": "Drag and Drop",


### PR DESCRIPTION
**Description**

This PR implements the following use case:

> As a learner, I want to place all items belonging to a drag-and-drop problem in assessment mode on the board first, and then check (submit) my answer by clicking a button.

Items dropped onto wrong zones in standard mode are immediately removed from the board and sent back to the bank.

In assessment mode, items should stick in the dropped position until the entire problem is explicitly submitted by clicking a button.

Note that the submit button and associated xhr handler will be implemented in a future PR.

*UX*

The workflow for placing items on the board should not change in assessment mode. However, items that were placed on an incorrect zone should stay on the board in assessment mode (at least until the learner checks their answer) instead of returning to the item bank.

Also, a drag-and-drop problem in assessment mode should not show per-item "Success Feedback" or "Error Feedback" to the learner as they place items on the board.

**JIRA tickets**: [SOL-1942](https://openedx.atlassian.net/browse/SOL-1942)

**Discussions**: [Discovery document for DnDv2 assessment mode](https://docs.google.com/document/d/1rFliZo1vlohJ7cde7KfP5bgEk0QqcvT1VNnUUa9_vjE/edit) (relevant section: 2.2.1)

**Dependencies**: None

**Screenshots**:

Items stick in dropped position even when dropped onto a wrong zone:

<img width="830" alt="screen shot 2016-07-20 at 19 40 22" src="https://cloud.githubusercontent.com/assets/32585/16985400/a4f7eb2a-4eb2-11e6-8206-e3e0d75d1815.png">

**Sandbox URLs** (ff7ddfd2ee734594459f5e96c18e453b8cc3ca92): 
- [Studio](http://studio-dndv2.opencraft.hosting/container/block-v1:OpenCraft+DNDv2+DEMO+type@vertical+block@90948135d1fb45afbb87622eb07f8f40)
- [LMS](http://dndv2.opencraft.hosting/courses/course-v1:OpenCraft+DNDv2+DEMO/courseware/6915ee3dd6ab403d8c05c0ea3180a0ee/8c5328b8b478441bac5d588bf76f0da2/1?activate_block_id=block-v1%3AOpenCraft%2BDNDv2%2BDEMO%2Btype%40vertical%2Bblock%4090948135d1fb45afbb87622eb07f8f40)

**Testing instructions**:

1. Add a DnDv2 block to a unit in Studio.
2. Click "EDIT" and change "Problem mode" to "assessment".
3. Drag items from the bank into drop zones. Place some items in wrong zones.
4. Observe that the items "stick" in the placed position (are not moved back to the bank). Observe that per-item feedbacks are not displayed.
5. Change "Problem mode" back to "standard".
6. Make sure everything still works correctly in standard mode.


**Author notes and concerns**:

When you reload the page after dragging some items on the board, the state of the board is not correct. Correctly placed items are left in their positioned (but faded out) while incorrectly placed items are sent back to the bank.
This behavior will be sorted out in future tickets.

**Reviewers**
- [x] @itsjeyd 
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: @cptvitamin and/or @clrux
- [x] Product: @sstack22