### PR TITLE
Move items between zones in assessment mode

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -143,6 +143,11 @@
     margin: 0;
     transform: translate(-50%, -50%); /* These blocks are to be centered on their absolute x,y position */
 }
+/* Dragging placed option to a different zone in assessment mode */
+.xblock--drag-and-drop .drag-container .target .option.grabbed-with-mouse {
+    transform: none; /* The transform messes with jQuery UI Draggable positioning, */
+                     /* so remove it while dragging with the mouse. */
+}
 
 /* Placed options in an aligned zone */
 .xblock--drag-and-drop .zone .item-wrapper {
@@ -172,20 +177,23 @@
 }
 
 /* Focused option */
-.xblock--drag-and-drop .drag-container .item-bank .option:focus,
-.xblock--drag-and-drop .drag-container .item-bank .option:hover,
-.xblock--drag-and-drop .drag-container .item-bank .option[aria-grabbed='true'] {
+.xblock--drag-and-drop .drag-container .option[draggable='true']:focus,
+.xblock--drag-and-drop .drag-container .option[draggable='true']:hover,
+.xblock--drag-and-drop .drag-container .option[draggable='true'][aria-grabbed='true'] {
     outline-width: 2px;
     outline-style: solid;
     outline-offset: -4px;
 }
 
-.xblock--drag-and-drop .drag-container .ui-draggable-dragging.option {
+.xblock--drag-and-drop .drag-container .option.grabbed-with-mouse {
     box-shadow: 0 16px 32px 0 rgba(0, 0, 0, 0.3);
     border: 1px solid #ccc;
     opacity: .65;
     z-index: 20 !important;
     margin: 0; /* Allow the draggable to touch the edges of the target image */
+}
+.xblock--drag-and-drop .drag-container .item-align-center .option.grabbed-with-mouse {
+    margin: 0 auto; /* Revert to auto margin when dragging with mouse to not confuse jQuery UI draggable */
 }
 
 .xblock--drag-and-drop .drag-container .option img {
@@ -254,8 +262,9 @@
 }
 
 /* Focused zone */
+.xblock--drag-and-drop .item-bank:focus,
 .xblock--drag-and-drop .zone:focus {
-    border: 2px solid #a5a5a5;
+    outline: 2px solid #a5a5a5;
 }
 
 .xblock--drag-and-drop .drag-container .target .zone p {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -4,16 +4,15 @@ function DragAndDropTemplates(configuration) {
     // Set up a mock for gettext if it isn't available in the client runtime:
     if (!window.gettext) { window.gettext = function gettext_stub(string) { return string; }; }
 
-    var itemSpinnerTemplate = function(xhr_active) {
-        if (!xhr_active) {
+    var itemSpinnerTemplate = function(item) {
+        if (!item.xhr_active) {
             return null;
         }
-        return (h(
-            "div.spinner-wrapper",
-            [
+        return (
+            h("div.spinner-wrapper", {key: item.value + '-spinner'}, [
                 h("i.fa.fa-spin.fa-spinner")
-            ]
-        ));
+            ])
+        );
     };
 
     var renderCollection = function(template, collection, ctx) {
@@ -50,7 +49,8 @@ function DragAndDropTemplates(configuration) {
         if (item.imageURL) {
             item_content_html = '<img src="' + item.imageURL + '" alt="' + item.imageDescription + '" />';
         }
-        return h('div', { innerHTML: item_content_html, className: "item-content" });
+        var key = item.value + '-content';
+        return h('div', { key: key, innerHTML: item_content_html, className: "item-content" });
     };
 
     var itemTemplate = function(item, ctx) {
@@ -113,7 +113,7 @@ function DragAndDropTemplates(configuration) {
         }
         // Define children
         var children = [
-            itemSpinnerTemplate(item.xhr_active)
+            itemSpinnerTemplate(item)
         ];
         var item_content = itemContentTemplate(item);
         if (item.is_placed) {
@@ -123,16 +123,16 @@ function DragAndDropTemplates(configuration) {
             var zone_title = (zone.title || "Unknown Zone");  // This "Unknown" text should never be seen, so does not need i18n
             var description_content;
             if (configuration.mode === DragAndDropBlock.ASSESSMENT_MODE) {
-              // In assessment mode placed items will "stick" even when not in correct zone.
-              description_content = gettext('Placed in: {zone_title}').replace('{zone_title}', zone_title);
+                // In assessment mode placed items will "stick" even when not in correct zone.
+                description_content = gettext('Placed in: {zone_title}').replace('{zone_title}', zone_title);
             } else {
-              // In standard mode item is immediately returned back to the bank if dropped on a wrong zone,
-              // so all placed items are always in the correct zone.
-              description_content = gettext('Correctly placed in: {zone_title}').replace('{zone_title}', zone_title);
+                // In standard mode item is immediately returned back to the bank if dropped on a wrong zone,
+                // so all placed items are always in the correct zone.
+                description_content = gettext('Correctly placed in: {zone_title}').replace('{zone_title}', zone_title);
             }
             var item_description = h(
                 'div',
-                { id: item_description_id, className: 'sr' },
+                { key: item.value + '-description', id: item_description_id, className: 'sr' },
                 description_content
             );
             children.splice(1, 0, item_description);

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -409,11 +409,15 @@ msgid "ok"
 msgstr ""
 
 #: public/js/drag_and_drop.js
-msgid "Placed in: "
+msgid "Item Bank"
 msgstr ""
 
 #: public/js/drag_and_drop.js
-msgid "Correctly placed in: "
+msgid "Placed in: {zone_title}"
+msgstr ""
+
+#: public/js/drag_and_drop.js
+msgid "Correctly placed in: {zone_title}"
 msgstr ""
 
 #: public/js/drag_and_drop.js

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -494,12 +494,16 @@ msgid "ok"
 msgstr "ök Ⱡ'σя#"
 
 #: public/js/drag_and_drop.js
-msgid "Placed in: "
-msgstr "Pläçéd ïn:  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+msgid "Item Bank"
+msgstr "Ìtém Bänk Ⱡ'σяєм ιρѕυм ∂σł#"
 
 #: public/js/drag_and_drop.js
-msgid "Correctly placed in: "
-msgstr "Çörréçtlý pläçéd ïn:  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+msgid "Placed in: {zone_title}"
+msgstr "Pläçéd ïn: {zone_title}  Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+
+#: public/js/drag_and_drop.js
+msgid "Correctly placed in: {zone_title}"
+msgstr "Çörréçtlý pläçéd ïn: {zone_title} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: public/js/drag_and_drop.js
 msgid "Reset problem"

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -146,7 +146,6 @@ class TestDragAndDropRender(BaseIntegrationTest):
             self.assertEqual(item.get_attribute('draggable'), 'true')
             self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
             self.assertEqual(item.get_attribute('data-value'), str(index))
-            self.assertIn('ui-draggable', self.get_element_classes(item))
             self._test_item_style(item, color_settings)
             try:
                 background_image = item.find_element_by_css_selector('img')
@@ -160,8 +159,16 @@ class TestDragAndDropRender(BaseIntegrationTest):
 
     def test_drag_container(self):
         self.load_scenario()
-        item_bank = self._page.find_element_by_css_selector('.drag-container')
-        self.assertIsNone(item_bank.get_attribute('role'))
+        drag_container = self._page.find_element_by_css_selector('.drag-container')
+        self.assertIsNone(drag_container.get_attribute('role'))
+
+    def test_item_bank(self):
+        self.load_scenario()
+        item_bank = self._page.find_element_by_css_selector('.item-bank')
+        description = item_bank.find_element_by_css_selector('p.zone-description')
+        self.assertEqual(description.text, 'Item Bank')
+        # Description should only be visible to screen readers:
+        self.assertEqual(description.get_attribute('class'), 'zone-description sr')
 
     def test_zones(self):
         self.load_scenario()

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -187,6 +187,7 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         target_img_width = target_img.size["width"]
         item_bank = self._page.find_element_by_css_selector('.item-bank')
         item_bank_width = item_bank.size["width"]
+        item_bank_height = item_bank.size["height"]
 
         if is_desktop:
             # If using a desktop-sized window, we can know the exact dimensions of various containers:
@@ -238,6 +239,10 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
                     self._get_placed_item_by_value(expect.item_id),
                     *expect.img_pixel_size_exact
                 )
+
+        # Test that the item bank maintains its original size.
+        self.assertEqual(item_bank.size["width"], item_bank_width)
+        self.assertEqual(item_bank.size["height"], item_bank_height)
 
 
 class AlignedSizingTests(SizingTests):


### PR DESCRIPTION
**Description**

This PR implements the following use case:

> As a learner, I want to be able to move items between drop targets before checking (submitting) my answer in assessment mode. This should be possible for any item, regardless of whether I placed it on a correct or incorrect zone before. I also want to be able to drag items back to the item bank without having to use the reset button.

*UX*

The existing implementation does not allow learners to move an item to a different zone once it has been placed on the board. We will keep this behavior for drag-and-drop problems in standard mode.

In assessment mode, learners should be able to move items that have already been placed on the board, regardless of whether they are located in a correct or incorrect zone. To do this, learners will be able to use the same workflows that are already established for moving items from the item bank to the board:

- Items can be moved to a different zone using the mouse. Workflow:
  1. Pick item up by clicking it.
  2. Drag item to desired zone.
  3. Drop item.
- Items can be moved to a different zone using the keyboard. Workflow:
  1. (Shift-)TAB to item.
  2. Pick item up by pressing "Enter", "Space", "Ctrl-m", or "⌘-m".
  3. TAB to desired zone.
  4. Drop item by pressing "Enter", "Space", "Ctrl-m", or "⌘-m".
  5. Press "Esc" to cancel drop operation.

With no item selected, learners will be able to (Shift-)TAB to items that have been placed on the board.

Once an item has been picked up, pressing (Shift-)TAB will only navigate between zones and the item bank.

**JIRA tickets**: [SOL-1943](https://openedx.atlassian.net/browse/SOL-1943)

**Discussions**: [Discovery document for DnDv2 assessment mode](https://docs.google.com/document/d/1rFliZo1vlohJ7cde7KfP5bgEk0QqcvT1VNnUUa9_vjE/edit) (relevant section: 2.2.2)

**Dependencies**: None

**Sandbox URLs** (installed version de0312bfbba02b850c9032a6db63c728924505f5):

- LMS: http://dndv2-sandbox5.opencraft.hosting/
- Studio: http://studio-dndv2-sandbox5.opencraft.hosting/

DnD example is located at http://dndv2-sandbox5.opencraft.hosting/courses/course-v1:OpenCraftX+OC1+1/courseware/bdeaa08976fa4645a277edcaf5e8148c/e8ec2f5c98f4436abf532cccd6a71668/1?activate_block_id=block-v1%3AOpenCraftX%2BOC1%2B1%2Btype%40vertical%2Bblock%40e3c62b19090948b8ad89d3386bff4435

**Testing instructions**:

1. Add a DnDv2 block to a unit in Studio.
2. Click "EDIT" and change "Problem mode" to "assessment".
3. Drag items from the bank into drop zones. You may place some items in wrong zones.
4. Drag and drop already placed items between zones, both with mouse and keyboard.
5. Observe that the items "stick" in the placed position (are not moved back to the bank or previous zone). Observe that per-item feedback is not displayed.
6. Drag some items back to the bank with both mouse and keyboard.
6. Change "Problem mode" back to "standard".
7. Make sure everything still works correctly in standard mode.

**Author notes and concerns**:

If you put multiple items into the same zone with keyboard in assessment mode, you can only see the topmost item, the rest of the items are hidden behind it (the same thing can happen when dragging with the mouse, but when dragging with the mouse you usually don't drop the item in *exactly* the same place, so parts of overlapping items are usually still visible).

Using the existing zone alignment feature (where you can specify how dropped items automatically align inside zones) prevents this problem.

**Reviewers**
- [x] OpenCraft/Solutions: @haikuginger  
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: @edx/edx-accessibility
- [ ] Product: @sstack22