### PR TITLE
[SOL-1806] Moved aria-live attributes to popup wrapper

### DIFF
--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -68,6 +68,9 @@ class BaseIntegrationTest(SeleniumBaseTest):
     def _get_popup(self):
         return self._page.find_element_by_css_selector(".popup")
 
+    def _get_popup_wrapper(self):
+        return self._page.find_element_by_css_selector(".popup-wrapper")
+
     def _get_popup_content(self):
         return self._page.find_element_by_css_selector(".popup .popup-content")
 
@@ -90,7 +93,7 @@ class BaseIntegrationTest(SeleniumBaseTest):
         return self._page.find_element_by_css_selector('.attempts-used')
 
     def _get_feedback(self):
-        return self._page.find_element_by_css_selector(".feedback")
+        return self._page.find_element_by_css_selector(".feedback-content")
 
     def _get_feedback_message(self):
         return self._page.find_element_by_css_selector(".feedback .message")

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -205,10 +205,12 @@ class TestDragAndDropRender(BaseIntegrationTest):
         self.load_scenario()
 
         popup = self._get_popup()
+        popup_wrapper = self._get_popup_wrapper()
         popup_content = self._get_popup_content()
         self.assertFalse(popup.is_displayed())
         self.assertEqual(popup.get_attribute('class'), 'popup')
         self.assertEqual(popup_content.text, "")
+        self.assertEqual(popup_wrapper.get_attribute('aria-live'), 'polite')
 
     def test_keyboard_help(self):
         self.load_scenario()


### PR DESCRIPTION
**Description:** This PR modifies ARIA attributes so that only feedback is read to screen-reader user when an item is dropped into a zone, instead of full "working field"

**JIRA:** [SOL-1806](https://openedx.atlassian.net/browse/SOL-1806)

**Testing instructions:**
0. Enable Screen Reader + make sure your browser support it (e.g. default Ubuntu screen reader does not work with Chrome, but works with Firefox).
0.a. Get used to it speaking out loud everything + learn to notice important parts of it.
1. Create Drag and Drop v2 XBlock in a course. Default configuration should be enough.
2. Open unit with DnDv2 in LMS.
3. Use keyboard or mouse to drop items into correct zones. *Expected behavior:* only feedback is read out loud. *Previous behavior:* almost everything were read out loud (all/some zones and items, feedback)
4. (Unconfirmed - see concerns below) Use keyboard or mouse to drop items into *incorrect* zones. *Expected behavior:* only feedback is read out loud. *Previous behavior:* almost everything were read out loud (all/some zones and items, feedback)

**Sandboxes:** 
LMS: http://dndv2-sandbox3.opencraft.hosting/
Studio: http://studio-dndv2-sandbox3.opencraft.hosting/

Sandboxes use 07ce4db8ba068050d771338b3d10d341a20b2b70 version

**Reviewers**

- [x] @mtyaka 
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: @cptvitamin
- [ ] Product: @sstack22

**Author concerns:**

Default Ubuntu screen reader seems to ignore error feedback popups (despite them being absolutely identical to normal popups). This behavior exists in current master, so I'm not sure if it is a real issue; and if so, should it be fixed in scope of this PR.