### PR TITLE
Click handlers and backend processing for assessment mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
     - "pip install dist/xblock-drag-and-drop-v2-2.0.7.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
-    - pylint drag_and_drop_v2 tests
+    - pylint drag_and_drop_v2
+    - pylint tests --rcfile=tests/pylintrc
     - python run_tests.py
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -96,11 +96,19 @@ and Drop component to a lesson, then click the `EDIT` button.
 
 ![Edit view](/doc/img/edit-view.png)
 
-In the first step, you can set some basic properties of the component,
-such as the title, the mode, the maximum number of attempts, the maximum score,
+In the first step, you can set some basic properties of the component, such as
+the title, the problem mode, the maximum number of attempts, the maximum score,
 the problem text to render above the background image, the introductory feedback
 (shown initially), and the final feedback (shown after the learner successfully
-completes the drag and drop problem).
+completes the drag and drop problem, or when the learner runs out of attempts).
+
+There are two problem modes available:
+
+* **Standard**: In this mode, the learner gets immediate feedback on each
+  attempt to place an item, and the number of attempts is not limited.
+* **Assessment**: In this mode, the learner places all items on the board and
+  then clicks a "Submit" button to get feedback.  The number of attempts can be
+  limited.
 
 ![Drop zone edit](/doc/img/edit-view-zones.png)
 
@@ -126,13 +134,14 @@ potentially, overlap the zones below.
 
 ![Drag item edit](/doc/img/edit-view-items.png)
 
-In the final step, you define the background and text color for drag
-items, as well as the drag items themselves. A drag item can contain
-either text or an image. You can define custom success and error
-feedback for each item. The feedback text is displayed in a popup
-after the learner drops the item on a zone - the success feedback is
-shown if the item is dropped on a correct zone, while the error
-feedback is shown when dropping the item on an incorrect drop zone.
+In the final step, you define the background and text color for drag items, as
+well as the drag items themselves. A drag item can contain either text or an
+image. You can define custom success and error feedback for each item. In
+standard mode, the feedback text is displayed in a popup after the learner drops
+the item on a zone - the success feedback is shown if the item is dropped on a
+correct zone, while the error feedback is shown when dropping the item on an
+incorrect drop zone.  In assessment mode, the success and error feedback texts
+are not used.
 
 You can select any number of zones for an item to belong to using
 the checkboxes; all zones defined in the previous step are available.

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,1 +1,2 @@
+""" Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock

--- a/drag_and_drop_v2/default_data.py
+++ b/drag_and_drop_v2/default_data.py
@@ -1,3 +1,4 @@
+""" Default data for Drag and Drop v2 XBlock """
 from .utils import _
 
 TARGET_IMG_DESCRIPTION = _(
@@ -27,100 +28,90 @@ START_FEEDBACK = _("Drag the items onto the image above.")
 FINISH_FEEDBACK = _("Good work! You have completed this drag and drop problem.")
 
 DEFAULT_DATA = {
-  "targetImgDescription": TARGET_IMG_DESCRIPTION,
-  "zones": [
-    {
-      "uid": TOP_ZONE_ID,
-      "title": TOP_ZONE_TITLE,
-      "description": TOP_ZONE_DESCRIPTION,
-      "x": 160,
-      "y": 30,
-      "width": 196,
-      "height": 178,
+    "targetImgDescription": TARGET_IMG_DESCRIPTION,
+    "zones": [
+        {
+            "uid": TOP_ZONE_ID,
+            "title": TOP_ZONE_TITLE,
+            "description": TOP_ZONE_DESCRIPTION,
+            "x": 160,
+            "y": 30,
+            "width": 196,
+            "height": 178,
+        },
+        {
+            "uid": MIDDLE_ZONE_ID,
+            "title": MIDDLE_ZONE_TITLE,
+            "description": MIDDLE_ZONE_DESCRIPTION,
+            "x": 86,
+            "y": 210,
+            "width": 340,
+            "height": 138,
+        },
+        {
+            "uid": BOTTOM_ZONE_ID,
+            "title": BOTTOM_ZONE_TITLE,
+            "description": BOTTOM_ZONE_DESCRIPTION,
+            "x": 15,
+            "y": 350,
+            "width": 485,
+            "height": 135,
+        }
+    ],
+    "items": [
+        {
+            "displayName": _("Goes to the top"),
+            "feedback": {
+                "incorrect": ITEM_INCORRECT_FEEDBACK,
+                "correct": ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE)
+            },
+            "zones": [TOP_ZONE_ID],
+            "imageURL": "",
+            "id": 0,
+        },
+        {
+            "displayName": _("Goes to the middle"),
+            "feedback": {
+                "incorrect": ITEM_INCORRECT_FEEDBACK,
+                "correct": ITEM_CORRECT_FEEDBACK.format(zone=MIDDLE_ZONE_TITLE)
+            },
+            "zones": [MIDDLE_ZONE_ID],
+            "imageURL": "",
+            "id": 1,
+        },
+        {
+            "displayName": _("Goes to the bottom"),
+            "feedback": {
+                "incorrect": ITEM_INCORRECT_FEEDBACK,
+                "correct": ITEM_CORRECT_FEEDBACK.format(zone=BOTTOM_ZONE_TITLE)
+            },
+            "zones": [BOTTOM_ZONE_ID],
+            "imageURL": "",
+            "id": 2,
+        },
+        {
+            "displayName": _("Goes anywhere"),
+            "feedback": {
+                "incorrect": "",
+                "correct": ITEM_ANY_ZONE_FEEDBACK
+            },
+            "zones": [TOP_ZONE_ID, BOTTOM_ZONE_ID, MIDDLE_ZONE_ID],
+            "imageURL": "",
+            "id": 3
+        },
+        {
+            "displayName": _("I don't belong anywhere"),
+            "feedback": {
+                "incorrect": ITEM_NO_ZONE_FEEDBACK,
+                "correct": ""
+            },
+            "zones": [],
+            "imageURL": "",
+            "id": 4,
+        },
+    ],
+    "feedback": {
+        "start": START_FEEDBACK,
+        "finish": FINISH_FEEDBACK,
     },
-    {
-      "uid": MIDDLE_ZONE_ID,
-      "title": MIDDLE_ZONE_TITLE,
-      "description": MIDDLE_ZONE_DESCRIPTION,
-      "x": 86,
-      "y": 210,
-      "width": 340,
-      "height": 138,
-    },
-    {
-      "uid": BOTTOM_ZONE_ID,
-      "title": BOTTOM_ZONE_TITLE,
-      "description": BOTTOM_ZONE_DESCRIPTION,
-      "x": 15,
-      "y": 350,
-      "width": 485,
-      "height": 135,
-    }
-  ],
-  "items": [
-    {
-      "displayName": _("Goes to the top"),
-      "feedback": {
-        "incorrect": ITEM_INCORRECT_FEEDBACK,
-        "correct": ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE)
-      },
-      "zones": [
-        TOP_ZONE_ID
-      ],
-      "imageURL": "",
-      "id": 0,
-    },
-    {
-      "displayName": _("Goes to the middle"),
-      "feedback": {
-        "incorrect": ITEM_INCORRECT_FEEDBACK,
-        "correct": ITEM_CORRECT_FEEDBACK.format(zone=MIDDLE_ZONE_TITLE)
-      },
-      "zones": [
-        MIDDLE_ZONE_ID
-      ],
-      "imageURL": "",
-      "id": 1,
-    },
-    {
-      "displayName": _("Goes to the bottom"),
-      "feedback": {
-        "incorrect": ITEM_INCORRECT_FEEDBACK,
-        "correct": ITEM_CORRECT_FEEDBACK.format(zone=BOTTOM_ZONE_TITLE)
-      },
-      "zones": [
-        BOTTOM_ZONE_ID
-      ],
-      "imageURL": "",
-      "id": 2,
-    },
-    {
-      "displayName": _("Goes anywhere"),
-      "feedback": {
-        "incorrect": "",
-        "correct": ITEM_ANY_ZONE_FEEDBACK
-      },
-      "zones": [
-        TOP_ZONE_ID,
-        BOTTOM_ZONE_ID,
-        MIDDLE_ZONE_ID
-      ],
-      "imageURL": "",
-      "id": 3
-    },
-    {
-      "displayName": _("I don't belong anywhere"),
-      "feedback": {
-        "incorrect": ITEM_NO_ZONE_FEEDBACK,
-        "correct": ""
-      },
-      "zones": [],
-      "imageURL": "",
-      "id": 4,
-    },
-  ],
-  "feedback": {
-    "start": START_FEEDBACK,
-    "finish": FINISH_FEEDBACK,
-  },
 }

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -284,6 +284,57 @@
     border-top: solid 1px #bdbdbd;
 }
 
+.xblock--drag-and-drop .feedback p {
+    margin: 2px 0;
+    padding: 0.5em;
+    border: 2px solid #999;
+}
+
+.xblock--drag-and-drop .feedback p.correct {
+    color: #166e36;
+    border: 2px solid #166e36;
+}
+
+.xblock--drag-and-drop .feedback p.partial {
+    color: #166e36;
+    border: 2px solid #166e36;
+}
+
+.xblock--drag-and-drop .feedback p.incorrect {
+    color: #b20610;
+    border: 2px solid #b20610;
+}
+
+
+/* Font Awesome icons have different width - margin-right tries to compensate it */
+.xblock--drag-and-drop .feedback p:before {
+    content: "\f129";
+    font-family: FontAwesome;
+    margin-right: 0.7em;
+    margin-left: 0.3em;
+}
+
+.xblock--drag-and-drop .feedback p.correct:before {
+    content: "\f00c";
+    font-family: FontAwesome;
+    margin-right: 0.3em;
+    margin-left: 0;
+}
+
+.xblock--drag-and-drop .feedback p.partial:before {
+    content: "\f069";
+    font-family: FontAwesome;
+    margin-right: 0.3em;
+    margin-left: 0;
+}
+
+.xblock--drag-and-drop .feedback p.incorrect:before {
+    content: "\f00d";
+    font-family: FontAwesome;
+    margin-right: 0.45em;
+    margin-left: 0.1em;
+}
+
 .xblock--drag-and-drop .popup {
     position: absolute;
     display: none;

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -286,10 +286,6 @@ msgid ""
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "Zones"
-msgstr ""
-
-#: templates/html/js_templates.html
 msgid "Use text that is clear and descriptive of the item to be placed"
 msgstr ""
 
@@ -323,6 +319,7 @@ msgstr ""
 msgid "Final Feedback"
 msgstr ""
 
+#: templates/html/js_templates.html
 #: templates/html/drag_and_drop_edit.html
 msgid "Zones"
 msgstr ""
@@ -421,7 +418,10 @@ msgid "Correctly placed in: {zone_title}"
 msgstr ""
 
 #: public/js/drag_and_drop.js
-msgid "Reset problem"
+msgid "Reset"
+msgstr ""
+
+msgid "Submit"
 msgstr ""
 
 #: public/js/drag_and_drop.js
@@ -485,3 +485,29 @@ msgstr ""
 #: public/js/drag_and_drop_edit.js
 msgid "Error: "
 msgstr ""
+
+#: utils.py:18
+msgid "Final attempt was used, highest score is {score}"
+msgstr ""
+
+#: utils.py:19
+msgid "Misplaced items were returned to item bank."
+msgstr ""
+
+#: utils.py:24
+msgid "Correctly placed {correct_count} item."
+msgid_plural "Correctly placed {correct_count} items."
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:32
+msgid "Misplaced {misplaced_count} item."
+msgid_plural "Misplaced {misplaced_count} items."
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:40
+msgid "Did not place {missing_count} required item."
+msgid_plural "Did not place {missing_count} required items."
+msgstr[0] ""
+msgstr[1] ""

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -164,6 +164,7 @@ msgstr ""
 "Ìf thé välüé ïs nöt sét, ïnfïnïté ättémpts äré ällöwéd. Ⱡ'σяєм #"
 
 #: drag_and_drop_v2.py
+#: templates/html/drag_and_drop_edit.html
 msgid "Show title"
 msgstr "Shöw tïtlé Ⱡ'σяєм ιρѕυм ∂σłσ#"
 
@@ -173,6 +174,7 @@ msgstr ""
 "Dïspläý thé tïtlé tö thé léärnér? Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
 
 #: drag_and_drop_v2.py
+#: templates/html/drag_and_drop_edit.html
 msgid "Problem text"
 msgstr "Prößlém téxt Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
@@ -349,6 +351,7 @@ msgstr ""
 "äütömätïç wïdth): Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σ#"
 
 #: templates/html/js_templates.html
+#: templates/html/drag_and_drop_edit.html
 msgid "Zones"
 msgstr "Zönés Ⱡ'σяєм ιρѕ#"
 
@@ -379,20 +382,8 @@ msgid "Problem mode"
 msgstr "Prößlém mödé Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Show title"
-msgstr "Shöw tïtlé Ⱡ'σяєм ιρѕυм ∂σłσ#"
-
-#: templates/html/drag_and_drop_edit.html
 msgid "Maximum score"
 msgstr "Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Problem text"
-msgstr "Prößlém téxt Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Show \"Problem\" heading"
-msgstr "Shöw \"Prößlém\" héädïng Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Introductory Feedback"
@@ -401,10 +392,6 @@ msgstr "Ìntrödüçtörý Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕ�
 #: templates/html/drag_and_drop_edit.html
 msgid "Final Feedback"
 msgstr "Fïnäl Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Zones"
-msgstr "Zönés Ⱡ'σяєм ιρѕ#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Background URL"
@@ -506,8 +493,11 @@ msgid "Correctly placed in: {zone_title}"
 msgstr "Çörréçtlý pläçéd ïn: {zone_title} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: public/js/drag_and_drop.js
-msgid "Reset problem"
-msgstr "Rését prößlém Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
+msgid "Reset"
+msgstr "Rését Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
+
+msgid "Submit"
+msgstr "Süßmït Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: public/js/drag_and_drop.js
 msgid "Feedback"
@@ -584,3 +574,30 @@ msgstr "Nöné Ⱡ'σяєм ι#"
 #: public/js/drag_and_drop_edit.js
 msgid "Error: "
 msgstr "Érrör:  Ⱡ'σяєм ιρѕυм #"
+
+
+#: utils.py:18
+msgid "Fïnäl ättémpt wäs üséd, hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
+msgstr ""
+
+#: utils.py:19
+msgid "Mïspläçéd ïtéms wéré rétürnéd tö ïtém ßänk. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
+msgstr ""
+
+#: utils.py:24
+msgid "Çörréçtlý pläçéd {correct_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
+msgid_plural "Çörréçtlý pläçéd {correct_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:32
+msgid "Mïspläçéd {misplaced_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
+msgid_plural "Mïspläçéd {misplaced_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:40
+msgid "Dïd nöt pläçé {missing_count} réqüïréd ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
+msgid_plural "Dïd nöt pläçé {missing_count} réqüïréd ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+msgstr[0] ""
+msgstr[1] ""

--- a/drag_and_drop_v2/utils.py
+++ b/drag_and_drop_v2/utils.py
@@ -1,7 +1,80 @@
 # -*- coding: utf-8 -*-
-#
+""" Drag and Drop v2 XBlock - Utils """
+from collections import namedtuple
 
 
-# Make '_' a no-op so we can scrape strings
 def _(text):
+    """ Dummy `gettext` replacement to make string extraction tools scrape strings marked for translation """
     return text
+
+
+def ngettext_fallback(text_singular, text_plural, number):
+    """ Dummy `ngettext` replacement to make string extraction tools scrape strings marked for translation """
+    if number == 1:
+        return text_singular
+    else:
+        return text_plural
+
+
+class DummyTranslationService(object):
+    """
+    Dummy drop-in replacement for i18n XBlock service
+    """
+    gettext = _
+    ngettext = ngettext_fallback
+
+
+class FeedbackMessages(object):
+    """
+    Feedback messages collection
+    """
+    class MessageClasses(object):
+        """
+        Namespace for message classes
+        """
+        CORRECT_SOLUTION = "correct"
+        PARTIAL_SOLUTION = "partial"
+        INCORRECT_SOLUTION = "incorrect"
+
+        CORRECTLY_PLACED = CORRECT_SOLUTION
+        MISPLACED = INCORRECT_SOLUTION
+        NOT_PLACED = INCORRECT_SOLUTION
+
+    FINAL_ATTEMPT_TPL = _('Final attempt was used, highest score is {score}')
+    MISPLACED_ITEMS_RETURNED = _('Misplaced item(s) were returned to item bank.')
+
+    @staticmethod
+    def correctly_placed(number, ngettext=ngettext_fallback):
+        """
+        Formats "correctly placed items" message
+        """
+        return ngettext(
+            'Correctly placed {correct_count} item.',
+            'Correctly placed {correct_count} items.',
+            number
+        ).format(correct_count=number)
+
+    @staticmethod
+    def misplaced(number, ngettext=ngettext_fallback):
+        """
+        Formats "misplaced items" message
+        """
+        return ngettext(
+            'Misplaced {misplaced_count} item. Misplaced item was returned to item bank.',
+            'Misplaced {misplaced_count} items. Misplaced items were returned to item bank.',
+            number
+        ).format(misplaced_count=number)
+
+    @staticmethod
+    def not_placed(number, ngettext=ngettext_fallback):
+        """
+        Formats "did not place required items" message
+        """
+        return ngettext(
+            'Did not place {missing_count} required item.',
+            'Did not place {missing_count} required items.',
+            number
+        ).format(missing_count=number)
+
+
+FeedbackMessage = namedtuple("FeedbackMessage", ["message", "message_class"])  # pylint: disable=invalid-name

--- a/pylintrc
+++ b/pylintrc
@@ -6,18 +6,19 @@ max-line-length=120
 
 [MESSAGES CONTROL]
 disable=
-    attribute-defined-outside-init,
     locally-disabled,
-    missing-docstring,
     too-many-ancestors,
-    too-many-arguments,
-    too-many-branches,
     too-many-instance-attributes,
     too-few-public-methods,
     too-many-public-methods,
-    unused-argument,
-    invalid-name,
-    no-member
+    unused-argument
 
 [SIMILARITIES]
 min-similarity-lines=4
+
+[OPTIONS]
+good-names=_,__,log,loader
+method-rgx=_?[a-z_][a-z0-9_]{2,40}$
+function-rgx=_?[a-z_][a-z0-9_]{2,40}$
+method-name-hint=_?[a-z_][a-z0-9_]{2,40}$
+function-name-hint=_?[a-z_][a-z0-9_]{2,40}$

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -1,0 +1,23 @@
+[REPORTS]
+reports=no
+
+[FORMAT]
+max-line-length=120
+
+[MESSAGES CONTROL]
+disable=
+    attribute-defined-outside-init,
+    locally-disabled,
+    missing-docstring,
+    abstract-class-little-used,
+    too-many-ancestors,
+    too-few-public-methods,
+    too-many-public-methods,
+    invalid-name,
+    no-member
+
+[SIMILARITIES]
+min-similarity-lines=4
+
+[OPTIONS]
+max-args=6

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -47,16 +47,22 @@
           "id": 1
         },
         {
+          "displayName": "3",
+          "imageURL": "",
+          "expandedImageURL": "",
+          "id": 2
+        },
+        {
           "displayName": "X",
           "imageURL": "/static/test_url_expansion",
           "expandedImageURL": "/course/test-course/assets/test_url_expansion",
-          "id": 2
+          "id": 3
         },
         {
           "displayName": "",
           "imageURL": "http://placehold.it/200x100",
           "expandedImageURL": "http://placehold.it/200x100",
-          "id": 3
+          "id": 4
         }
     ]
 }

--- a/tests/unit/data/assessment/data.json
+++ b/tests/unit/data/assessment/data.json
@@ -41,6 +41,16 @@
       "id": 1
     },
     {
+      "displayName": "3",
+      "feedback": {
+        "incorrect": "No 3",
+        "correct": "Yes 3"
+      },
+      "zone": "zone-2",
+      "imageURL": "",
+      "id": 2
+    },
+    {
       "displayName": "X",
       "feedback": {
         "incorrect": "",
@@ -48,7 +58,7 @@
       },
       "zone": "none",
       "imageURL": "/static/test_url_expansion",
-      "id": 2
+      "id": 3
     },
     {
       "displayName": "",
@@ -58,7 +68,7 @@
       },
       "zone": "none",
       "imageURL": "http://placehold.it/200x100",
-      "id": 3
+      "id": 4
     }
   ],
 

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -1,11 +1,16 @@
 # Imports ###########################################################
 
+import ddt
 import json
+import mock
+import random
 import unittest
 
 from xblockutils.resources import ResourceLoader
 
-from ..utils import make_block, TestCaseMixin
+from drag_and_drop_v2.utils import FeedbackMessages
+
+from ..utils import make_block, TestCaseMixin, generate_max_and_attempts
 
 
 # Globals ###########################################################
@@ -18,6 +23,8 @@ loader = ResourceLoader(__name__)
 class BaseDragAndDropAjaxFixture(TestCaseMixin):
     ZONE_1 = None
     ZONE_2 = None
+
+    OVERALL_FEEDBACK_KEY = 'overall_feedback'
 
     FEEDBACK = {
         0: {"correct": None, "incorrect": None},
@@ -36,6 +43,10 @@ class BaseDragAndDropAjaxFixture(TestCaseMixin):
         for field in initial_settings:
             setattr(self.block, field, initial_settings[field])
         self.block.data = self.initial_data()
+
+    @staticmethod
+    def _make_feedback_message(message=None, message_class=None):
+        return {"message": message, "message_class": message_class}
 
     @classmethod
     def initial_data(cls):
@@ -62,34 +73,34 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
     """
     Common tests for drag and drop in standard mode
     """
-    def test_do_attempt_wrong_with_feedback(self):
+    def test_drop_item_wrong_with_feedback(self):
         item_id, zone_id = 0, self.ZONE_2
         data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
-        res = self.call_handler('do_attempt', data)
+        res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
-            "overall_feedback": None,
+            "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
             "finished": False,
             "correct": False,
             "feedback": self.FEEDBACK[item_id]["incorrect"]
         })
 
-    def test_do_attempt_wrong_without_feedback(self):
+    def test_drop_item_wrong_without_feedback(self):
         item_id, zone_id = 2, self.ZONE_1
         data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
-        res = self.call_handler('do_attempt', data)
+        res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
-            "overall_feedback": None,
+            "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
             "finished": False,
             "correct": False,
             "feedback": self.FEEDBACK[item_id]["incorrect"]
         })
 
-    def test_do_attempt_correct(self):
+    def test_drop_item_correct(self):
         item_id, zone_id = 0, self.ZONE_1
         data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
-        res = self.call_handler('do_attempt', data)
+        res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
-            "overall_feedback": None,
+            "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
             "finished": False,
             "correct": True,
             "feedback": self.FEEDBACK[item_id]["correct"]
@@ -98,43 +109,43 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
     def test_grading(self):
         published_grades = []
 
-        def mock_publish(self, event, params):
+        def mock_publish(_, event, params):
             if event == 'grade':
                 published_grades.append(params)
         self.block.runtime.publish = mock_publish
 
-        self.call_handler('do_attempt', {
+        self.call_handler(self.DROP_ITEM_HANDLER, {
             "val": 0, "zone": self.ZONE_1, "y_percent": "11%", "x_percent": "33%"
         })
 
         self.assertEqual(1, len(published_grades))
         self.assertEqual({'value': 0.5, 'max_value': 1}, published_grades[-1])
 
-        self.call_handler('do_attempt', {
+        self.call_handler(self.DROP_ITEM_HANDLER, {
             "val": 1, "zone": self.ZONE_2, "y_percent": "90%", "x_percent": "42%"
         })
 
         self.assertEqual(2, len(published_grades))
         self.assertEqual({'value': 1, 'max_value': 1}, published_grades[-1])
 
-    def test_do_attempt_final(self):
+    def test_drop_item_final(self):
         data = {"val": 0, "zone": self.ZONE_1, "x_percent": "33%", "y_percent": "11%"}
-        self.call_handler('do_attempt', data)
+        self.call_handler(self.DROP_ITEM_HANDLER, data)
 
         expected_state = {
             "items": {
                 "0": {"x_percent": "33%", "y_percent": "11%", "correct": True, "zone": self.ZONE_1}
             },
             "finished": False,
-            "num_attempts": 0,
-            'overall_feedback': self.initial_feedback(),
+            "attempts": 0,
+            'overall_feedback': [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
         }
         self.assertEqual(expected_state, self.call_handler('get_user_state', method="GET"))
 
         data = {"val": 1, "zone": self.ZONE_2, "x_percent": "22%", "y_percent": "22%"}
-        res = self.call_handler('do_attempt', data)
+        res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
-            "overall_feedback": self.FINAL_FEEDBACK,
+            "overall_feedback": [self._make_feedback_message(message=self.FINAL_FEEDBACK)],
             "finished": True,
             "correct": True,
             "feedback": self.FEEDBACK[1]["correct"]
@@ -150,22 +161,224 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
                 }
             },
             "finished": True,
-            "num_attempts": 0,
-            'overall_feedback': self.FINAL_FEEDBACK,
+            "attempts": 0,
+            'overall_feedback': [self._make_feedback_message(self.FINAL_FEEDBACK)],
         }
         self.assertEqual(expected_state, self.call_handler('get_user_state', method="GET"))
 
+    def test_do_attempt_not_available(self):
+        """
+        Tests that do_attempt handler returns 400 error for standard mode DnDv2
+        """
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, expect_json=False)
 
+        self.assertEqual(res.status_code, 400)
+
+
+@ddt.ddt
 class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
     """
     Common tests for drag and drop in assessment mode
     """
-    def test_do_attempt_in_assessment_mode(self):
-        item_id, zone_id = 0, self.ZONE_1
-        data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
-        res = self.call_handler('do_attempt', data)
-        # In assessment mode, the do_attempt doesn't return any data.
-        self.assertEqual(res, {})
+    @staticmethod
+    def _make_submission(item_id, zone_id):
+        x_percent, y_percent = str(random.randint(0, 100)) + '%', str(random.randint(0, 100)) + '%'
+        data = {"val": item_id, "zone": zone_id, "x_percent": x_percent, "y_percent": y_percent}
+        return data
+
+    def _submit_solution(self, solution):
+        for item_id, zone_id in solution.iteritems():
+            data = self._make_submission(item_id, zone_id)
+            self.call_handler(self.DROP_ITEM_HANDLER, data)
+
+    def _submit_complete_solution(self):  # pylint: disable=no-self-use
+        raise NotImplementedError()
+
+    def _submit_partial_solution(self):  # pylint: disable=no-self-use
+        raise NotImplementedError()
+
+    def _reset_problem(self):
+        self.call_handler(self.RESET_HANDLER, data={})
+        self.assertEqual(self.block.item_state, {})
+
+    def _set_final_attempt(self):
+        self.block.max_attempts = 5
+        self.block.attempts = 4
+
+    def test_multiple_drop_item(self):
+        item_zone_map = {0: self.ZONE_1, 1: self.ZONE_2}
+        for item_id, zone_id in item_zone_map.iteritems():
+            data = self._make_submission(item_id, zone_id)
+            x_percent, y_percent = data['x_percent'], data['y_percent']
+            res = self.call_handler(self.DROP_ITEM_HANDLER, data)
+
+            self.assertEqual(res, {})
+
+            expected_item_state = {'zone': zone_id, 'correct': True, 'x_percent': x_percent, 'y_percent': y_percent}
+
+            self.assertIn(str(item_id), self.block.item_state)
+            self.assertEqual(self.block.item_state[str(item_id)], expected_item_state)
+
+        # make sure item_state is appended to, not reset
+        for item_id in item_zone_map:
+            self.assertIn(str(item_id), self.block.item_state)
+
+    def test_get_user_state_no_attempts(self):
+        self.block.attempts = 0
+
+        res = self.call_handler(self.USER_STATE_HANDLER, data={})
+        expected_feedback = [
+            self._make_feedback_message(self.INITIAL_FEEDBACK)
+        ]
+        self.assertEqual(res[self.OVERALL_FEEDBACK_KEY], expected_feedback)
+
+    # pylint: disable=star-args
+    @ddt.data(
+        (None, 10, False),
+        (0, 12, False),
+        *(generate_max_and_attempts())
+    )
+    @ddt.unpack
+    def test_do_attempt_validation(self, max_attempts, attempts, expect_validation_error):
+        self.block.max_attempts = max_attempts
+        self.block.attempts = attempts
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={}, expect_json=False)
+
+        if expect_validation_error:
+            self.assertEqual(res.status_code, 409)
+        else:
+            self.assertEqual(res.status_code, 200)
+
+    @ddt.data(*[random.randint(0, 100) for _ in xrange(10)])  # pylint: disable=star-args
+    def test_do_attempt_raises_number_of_attempts(self, attempts):
+        self.block.attempts = attempts
+        self.block.max_attempts = attempts + 1
+
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        self.assertEqual(self.block.attempts, attempts + 1)
+        self.assertEqual(res['attempts'], self.block.attempts)
+
+    def test_do_attempt_correct_mark_complete_and_publish_grade(self):
+        self._submit_complete_solution()
+
+        with mock.patch('workbench.runtime.WorkbenchRuntime.publish', mock.Mock()) as patched_publish:
+            self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+            self.assertTrue(self.block.completed)
+            patched_publish.assert_called_once_with(self.block, 'grade', {
+                'value': self.block.weight,
+                'max_value': self.block.weight,
+            })
+
+    def test_do_attempt_incorrect_publish_grade(self):
+        correctness = self._submit_partial_solution()
+
+        with mock.patch('workbench.runtime.WorkbenchRuntime.publish', mock.Mock()) as patched_publish:
+            self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+            self.assertFalse(self.block.completed)
+            patched_publish.assert_called_once_with(self.block, 'grade', {
+                'value': self.block.weight * correctness,
+                'max_value': self.block.weight,
+            })
+
+    def test_do_attempt_post_correct_no_publish_grade(self):
+        self._submit_complete_solution()
+
+        self.call_handler(self.DO_ATTEMPT_HANDLER, data={})  # sets self.complete
+
+        self._reset_problem()
+
+        with mock.patch('workbench.runtime.WorkbenchRuntime.publish', mock.Mock()) as patched_publish:
+            self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+            self.assertTrue(self.block.completed)
+            self.assertFalse(patched_publish.called)
+
+    def test_get_user_state_finished_after_final_attempt(self):
+        self._set_final_attempt()
+        self._submit_partial_solution()
+        self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+        self.assertFalse(self.block.attempts_remain)  # precondition check
+
+        res = self.call_handler(self.USER_STATE_HANDLER, data={})
+        self.assertTrue(res['finished'])
+
+    def test_do_attempt_incorrect_final_attempt_publish_grade(self):
+        self._set_final_attempt()
+
+        correctness = self._submit_partial_solution()
+        expected_grade = self.block.weight * correctness
+
+        with mock.patch('workbench.runtime.WorkbenchRuntime.publish', mock.Mock()) as patched_publish:
+            res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+            self.assertTrue(self.block.completed)
+            patched_publish.assert_called_once_with(self.block, 'grade', {
+                'value': expected_grade,
+                'max_value': self.block.weight,
+            })
+
+            expected_grade_feedback = self._make_feedback_message(
+                FeedbackMessages.FINAL_ATTEMPT_TPL.format(score=expected_grade),
+                FeedbackMessages.MessageClasses.PARTIAL_SOLUTION
+            )
+            self.assertIn(expected_grade_feedback, res[self.OVERALL_FEEDBACK_KEY])
+
+    def test_do_attempt_incorrect_final_attempt_after_correct(self):
+        self._submit_complete_solution()
+        self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+        self.assertTrue(self.block.completed)  # precondition check
+        self.assertEqual(self.block.grade, 1.0)  # precondition check
+
+        self._reset_problem()
+
+        self._set_final_attempt()
+
+        self._submit_partial_solution()
+
+        with mock.patch('workbench.runtime.WorkbenchRuntime.publish', mock.Mock()) as patched_publish:
+            res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+
+            expected_grade_feedback = self._make_feedback_message(
+                FeedbackMessages.FINAL_ATTEMPT_TPL.format(score=1.0),
+                FeedbackMessages.MessageClasses.PARTIAL_SOLUTION
+            )
+            self.assertFalse(patched_publish.called)
+            self.assertIn(expected_grade_feedback, res[self.OVERALL_FEEDBACK_KEY])
+            self.assertEqual(self.block.grade, 1.0)
+
+    def test_do_attempt_misplaced_ids(self):
+        misplaced_ids = self._submit_incorrect_solution()
+
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        self.assertTrue(res['misplaced_items'], misplaced_ids)
+        self.assertIn(
+            self._make_feedback_message(FeedbackMessages.MISPLACED_ITEMS_RETURNED),
+            res[self.OVERALL_FEEDBACK_KEY]
+        )
+
+    def test_do_attempt_shows_final_feedback_at_last_attempt(self):
+        self._set_final_attempt()
+
+        self._submit_partial_solution()
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        expected_message = self._make_feedback_message(self.FINAL_FEEDBACK)
+        self.assertIn(expected_message, res[self.OVERALL_FEEDBACK_KEY])
+
+    def test_get_user_state_does_not_include_correctness(self):
+        self._submit_complete_solution()
+        original_item_state = self.block.item_state
+
+        res = self.call_handler(self.USER_STATE_HANDLER)
+
+        item_data = res['items']
+        for item in item_data:
+            self.assertNotIn('correct', item)
+
+        self.assertEqual(self.block.item_state, original_item_state)
 
 
 class TestDragAndDropHtmlData(StandardModeFixture, unittest.TestCase):
@@ -180,6 +393,7 @@ class TestDragAndDropHtmlData(StandardModeFixture, unittest.TestCase):
         2: {"correct": "", "incorrect": ""}
     }
 
+    INITIAL_FEEDBACK = "HTML <strong>Intro</strong> Feed"
     FINAL_FEEDBACK = "Final <strong>feedback</strong>!"
 
 
@@ -195,6 +409,7 @@ class TestDragAndDropPlainData(StandardModeFixture, unittest.TestCase):
         2: {"correct": "", "incorrect": ""}
     }
 
+    INITIAL_FEEDBACK = "This is the initial feedback."
     FINAL_FEEDBACK = "This is the final feedback."
 
 
@@ -203,6 +418,8 @@ class TestOldDataFormat(TestDragAndDropPlainData):
     Make sure we can work with the slightly-older format for 'data' field values.
     """
     FOLDER = "old"
+
+    INITIAL_FEEDBACK = "Intro Feed"
     FINAL_FEEDBACK = "Final Feed"
 
     ZONE_1 = "Zone 1"
@@ -221,4 +438,102 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
         2: {"correct": "", "incorrect": ""}
     }
 
+    INITIAL_FEEDBACK = "This is the initial feedback."
     FINAL_FEEDBACK = "This is the final feedback."
+
+    def _submit_complete_solution(self):
+        self._submit_solution({0: self.ZONE_1, 1: self.ZONE_2, 2: self.ZONE_2})
+
+    def _submit_partial_solution(self):
+        self._submit_solution({0: self.ZONE_1})
+        return 1.0 / 3.0
+
+    def _submit_incorrect_solution(self):
+        self._submit_solution({0: self.ZONE_2, 1: self.ZONE_1})
+        return 0, 1
+
+    def test_do_attempt_feedback_incorrect_not_placed(self):
+        self._submit_solution({0: self.ZONE_2, 1: self.ZONE_2})
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        overall_feedback = res[self.OVERALL_FEEDBACK_KEY]
+        expected_overall_feedback = [
+            self._make_feedback_message(
+                FeedbackMessages.correctly_placed(1), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+            ),
+            self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED),
+            self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
+            self._make_feedback_message(FeedbackMessages.MISPLACED_ITEMS_RETURNED, None),
+            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+        ]
+        self.assertEqual(overall_feedback, expected_overall_feedback)
+
+    def test_do_attempt_feedback_not_placed(self):
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        overall_feedback = res[self.OVERALL_FEEDBACK_KEY]
+        expected_overall_feedback = [
+            self._make_feedback_message(FeedbackMessages.not_placed(3), FeedbackMessages.MessageClasses.NOT_PLACED),
+            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+        ]
+        self.assertEqual(overall_feedback, expected_overall_feedback)
+
+    def test_do_attempt_feedback_correct_and_decoy(self):
+        self._submit_solution({0: self.ZONE_1, 1: self.ZONE_2, 3: self.ZONE_2})  # incorrect solution - decoy placed
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        overall_feedback = res[self.OVERALL_FEEDBACK_KEY]
+        expected_overall_feedback = [
+            self._make_feedback_message(
+                FeedbackMessages.correctly_placed(2), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+            ),
+            self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED),
+            self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
+            self._make_feedback_message(FeedbackMessages.MISPLACED_ITEMS_RETURNED, None),
+            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+        ]
+        self.assertEqual(overall_feedback, expected_overall_feedback)
+
+    def test_do_attempt_feedback_correct(self):
+        self._submit_solution({0: self.ZONE_1, 1: self.ZONE_2, 2: self.ZONE_2})  # correct solution
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        overall_feedback = res[self.OVERALL_FEEDBACK_KEY]
+        expected_overall_feedback = [
+            self._make_feedback_message(
+                FeedbackMessages.correctly_placed(3), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+            ),
+            self._make_feedback_message(self.FINAL_FEEDBACK, FeedbackMessages.MessageClasses.CORRECT_SOLUTION),
+        ]
+        self.assertEqual(overall_feedback, expected_overall_feedback)
+
+    def test_do_attempt_feedback_partial(self):
+        self._submit_solution({0: self.ZONE_1})  # partial solution
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        overall_feedback = res[self.OVERALL_FEEDBACK_KEY]
+        expected_overall_feedback = [
+            self._make_feedback_message(
+                FeedbackMessages.correctly_placed(1), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+            ),
+            self._make_feedback_message(FeedbackMessages.not_placed(2), FeedbackMessages.MessageClasses.NOT_PLACED),
+            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+        ]
+        self.assertEqual(overall_feedback, expected_overall_feedback)
+
+    def test_do_attempt_keeps_highest_score(self):
+        self.assertFalse(self.block.completed)  # precondition check
+        expected_score = 2.0 / 3.0
+
+        self._submit_solution({0: self.ZONE_1, 1: self.ZONE_2})  # partial solution, 0.66 score
+        self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        self.assertEqual(self.block.grade, expected_score)
+
+        self._reset_problem()
+        # make it a last attempt so we can check feedback
+        self._set_final_attempt()
+
+        self._submit_solution({0: self.ZONE_1})  # partial solution, 0.33 score
+        res = self.call_handler(self.DO_ATTEMPT_HANDLER, data={})
+        self.assertEqual(self.block.grade, expected_score)
+
+        expected_feedback = self._make_feedback_message(
+            FeedbackMessages.FINAL_ATTEMPT_TPL.format(score=expected_score),
+            FeedbackMessages.MessageClasses.PARTIAL_SOLUTION
+        )
+        self.assertIn(expected_feedback, res[self.OVERALL_FEEDBACK_KEY])

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -69,20 +69,20 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             self.assertEqual(self.call_handler("get_user_state"), {
                 'items': {},
                 'finished': False,
-                "num_attempts": 0,
-                'overall_feedback': START_FEEDBACK,
+                "attempts": 0,
+                'overall_feedback': [{"message": START_FEEDBACK, "message_class": None}]
             })
         assert_user_state_empty()
 
         # Drag three items into the correct spot:
         data = {"val": 0, "zone": TOP_ZONE_ID, "x_percent": "33%", "y_percent": "11%"}
-        self.call_handler('do_attempt', data)
+        self.call_handler(self.DROP_ITEM_HANDLER, data)
         data = {"val": 1, "zone": MIDDLE_ZONE_ID, "x_percent": "67%", "y_percent": "80%"}
-        self.call_handler('do_attempt', data)
+        self.call_handler(self.DROP_ITEM_HANDLER, data)
         data = {"val": 2, "zone": BOTTOM_ZONE_ID, "x_percent": "99%", "y_percent": "95%"}
-        self.call_handler('do_attempt', data)
+        self.call_handler(self.DROP_ITEM_HANDLER, data)
         data = {"val": 3, "zone": MIDDLE_ZONE_ID, "x_percent": "67%", "y_percent": "80%"}
-        self.call_handler('do_attempt', data)
+        self.call_handler(self.DROP_ITEM_HANDLER, data)
 
         # Check the result:
         self.assertTrue(self.block.completed)
@@ -100,8 +100,8 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
                 '3': {'x_percent': '67%', 'y_percent': '80%', 'correct': True, "zone": MIDDLE_ZONE_ID},
             },
             'finished': True,
-            "num_attempts": 0,
-            'overall_feedback': FINISH_FEEDBACK,
+            "attempts": 0,
+            'overall_feedback': [{"message": FINISH_FEEDBACK, "message_class": None}],
         })
 
         # Reset to initial conditions

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import json
+import random
 import re
 
 from mock import patch
@@ -31,9 +32,22 @@ def make_block():
     return drag_and_drop_v2.DragAndDropBlock(runtime, field_data, scope_ids=scope_ids)
 
 
+def generate_max_and_attempts(count=100):
+    for _ in xrange(count):
+        max_attempts = random.randint(1, 100)
+        attempts = random.randint(0, 100)
+        expect_validation_error = max_attempts <= attempts
+        yield max_attempts, attempts, expect_validation_error
+
+
 class TestCaseMixin(object):
     """ Helpful mixins for unittest TestCase subclasses """
     maxDiff = None
+
+    DROP_ITEM_HANDLER = 'drop_item'
+    DO_ATTEMPT_HANDLER = 'do_attempt'
+    RESET_HANDLER = 'reset'
+    USER_STATE_HANDLER = 'get_user_state'
 
     def patch_workbench(self):
         self.apply_patch(


### PR DESCRIPTION
**Description:** This PR actually implements submitting attempts for Assessment Mode. As of this PR, the minimum viable product implementation of Assessment Mode in Drag and Drop v2 is complete.

**Dependencies:** #86 (now merged)

**JIRA:** Part of [SOL-1944](https://openedx.atlassian.net/browse/SOL-1944)

**Discussions**: [Discovery document for DnDv2 assessment mode](https://docs.google.com/document/d/1rFliZo1vlohJ7cde7KfP5bgEk0QqcvT1VNnUUa9_vjE/edit) (relevant section: 2.2.3)

**Sandbox URLs**: 
* LMS: http://dndv2-sandbox8.opencraft.hosting/
* Studio: http://studio-dndv2-sandbox8.opencraft.hosting/

Updated 2016-08-12 to commit 5b837e7

**Testing instructions:**
1. Create/edit DnDv2; put it into assessment mode
2. Set "Max attempts" to N: N > 2
3. Publish, open in LMS.
4. Note that "Submit" button is displayed. Make sure problem is in its initial state (reset if needed). Submit button should be disabled. Attempts info should not be displayed.
5. Put any item to correct zone. "Submit" button should become enabled.
6. Click "Submit". Expected to happen:
6.1. Submit button shows spinner until AJAX request is sent
6.2. When AJAX is completed, incorrect items are returned to item bank, other items stay where they were.
6.3. Feedback message is updated to contain info about correctly placed items, misplaced items and items that should be put, but was not. If there were any misplaced items, feedback should also contain note about them being returned to item bank. If "initial" overall feedback is specified, it should be shown as well.
6.4. Attempts info should increase the number of used attempts.
7. Use N-1 attempts to test various combinations of correct, misplaced and missing items (note pluralization should be appropriate). Same things as in (6) should happen.
8. Submit final attempt. Expected to happen:
8.1. Same as 6.1. - spinner
8.2. All items stay where they were (misplaced are not returned to bank, as opposed to 6.2)
8.3. All of 6.3 + note about using final attempt and final grade are shown.
8.4. Attempts info should read "Used N of N attempts".
8.5. Submit and Reset buttons are permanently disabled.

**Reviewers**
- [x] @mtyaka 
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: @cptvitamin
- [ ] Product: @sstack22