### PR TITLE
Clean up studio edit template

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -255,19 +255,10 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         # connect 'for' and 'aria-describedby' attributes to the associated elements.
         id_suffix = uuid.uuid4().hex[:16]
         js_templates = js_templates.replace('{{id_suffix}}', id_suffix)
-        help_texts = {
-            field_name: self.ugettext(field.help)
-            for field_name, field in self.fields.viewitems() if hasattr(field, "help")
-        }
-        field_values = {
-            field_name: field.values
-            for field_name, field in self.fields.viewitems() if hasattr(field, "values")
-        }
         context = {
             'js_templates': js_templates,
-            'help_texts': help_texts,
-            'field_values': field_values,
             'id_suffix': id_suffix,
+            'fields': self.fields,
             'self': self,
             'data': urllib.quote(json.dumps(self.data)),
         }

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -115,14 +115,14 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
 
     item_background_color = String(
         display_name=_("Item background color"),
-        help=_("The background color of draggable items in the problem (e.g. 'blue' or '#0000ff')."),
+        help=_("The background color of draggable items in the problem (example: 'blue' or '#0000ff')."),
         scope=Scope.settings,
         default="",
     )
 
     item_text_color = String(
         display_name=_("Item text color"),
-        help=_("Text color to use for draggable items (e.g. 'white' or '#ffffff')."),
+        help=_("Text color to use for draggable items (example: 'white' or '#ffffff')."),
         scope=Scope.settings,
         default="",
     )

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -106,7 +106,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
     )
 
     weight = Float(
-        display_name=_("Weight"),
+        display_name=_("Maximum score"),
         help=_("The maximum score the learner can receive for the problem"),
         scope=Scope.settings,
         default=1,

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 #
 """ Drag and Drop v2 XBlock """
+
 # Imports ###########################################################
 
 import copy
 import json
 import urllib
+import uuid
 import webob
 
 from xblock.core import XBlock
@@ -247,6 +249,12 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         """
 
         js_templates = loader.load_unicode('/templates/html/js_templates.html')
+        # A short random string to append to HTML element ID attributes to avoid multiple instances
+        # of the DnDv2 block on the same page sharing the same ID values.
+        # We avoid using ID attributes in preference to classes, but sometimes we still need IDs to
+        # connect 'for' and 'aria-describedby' attributes to the associated elements.
+        id_suffix = uuid.uuid4().hex[:16]
+        js_templates = js_templates.replace('{{id_suffix}}', id_suffix)
         help_texts = {
             field_name: self.ugettext(field.help)
             for field_name, field in self.fields.viewitems() if hasattr(field, "help")
@@ -259,6 +267,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
             'js_templates': js_templates,
             'help_texts': help_texts,
             'field_values': field_values,
+            'id_suffix': id_suffix,
             'self': self,
             'data': urllib.quote(json.dumps(self.data)),
         }

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -7,7 +7,6 @@
 import copy
 import json
 import urllib
-import uuid
 import webob
 
 from xblock.core import XBlock
@@ -95,7 +94,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
 
     question_text = String(
         display_name=_("Problem text"),
-        help=_("The description of the problem or instructions shown to the learner"),
+        help=_("The description of the problem or instructions shown to the learner."),
         scope=Scope.settings,
         default="",
     )
@@ -109,21 +108,21 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
 
     weight = Float(
         display_name=_("Maximum score"),
-        help=_("The maximum score the learner can receive for the problem"),
+        help=_("The maximum score the learner can receive for the problem."),
         scope=Scope.settings,
         default=1,
     )
 
     item_background_color = String(
         display_name=_("Item background color"),
-        help=_("The background color of draggable items in the problem."),
+        help=_("The background color of draggable items in the problem (e.g. 'blue' or '#0000ff')."),
         scope=Scope.settings,
         default="",
     )
 
     item_text_color = String(
         display_name=_("Item text color"),
-        help=_("Text color to use for draggable items."),
+        help=_("Text color to use for draggable items (e.g. 'white' or '#ffffff')."),
         scope=Scope.settings,
         default="",
     )
@@ -249,11 +248,12 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         """
 
         js_templates = loader.load_unicode('/templates/html/js_templates.html')
-        # A short random string to append to HTML element ID attributes to avoid multiple instances
-        # of the DnDv2 block on the same page sharing the same ID values.
+        # Get a 'html_id' string that is unique for this block.
+        # We append it to HTML element ID attributes to ensure multiple instances of the DnDv2 block
+        # on the same page don't share the same ID value.
         # We avoid using ID attributes in preference to classes, but sometimes we still need IDs to
         # connect 'for' and 'aria-describedby' attributes to the associated elements.
-        id_suffix = uuid.uuid4().hex[:16]
+        id_suffix = self.location.html_id()
         js_templates = js_templates.replace('{{id_suffix}}', id_suffix)
         context = {
             'js_templates': js_templates,

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -253,7 +253,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         # on the same page don't share the same ID value.
         # We avoid using ID attributes in preference to classes, but sometimes we still need IDs to
         # connect 'for' and 'aria-describedby' attributes to the associated elements.
-        id_suffix = self.location.html_id()
+        id_suffix = self.location.html_id()  # pylint: disable=no-member
         js_templates = js_templates.replace('{{id_suffix}}', id_suffix)
         context = {
             'js_templates': js_templates,

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -68,15 +68,19 @@
   clear: both;
 }
 
-.xblock--drag-and-drop--editor .tab h3,
-.xblock--drag-and-drop--editor .tab .h3 {
+.xblock--drag-and-drop--editor .tab h3 {
+    font-size: 18px;
+}
+
+.xblock--drag-and-drop--editor .tab h4,
+.xblock--drag-and-drop--editor .tab .h4 {
+    display: block;
+    font-size: 16px;
     margin: 20px 0 8px 0;
 }
 
-.xblock--drag-and-drop--editor .tab .h3 {
-    display: block;
-    font: inherit;
-    font-size: 100%;
+.xblock--drag-and-drop--editor .tab .items-form .item .row:first-of-type .h4 {
+    margin-top: 0;
 }
 
 .xblock--drag-and-drop--editor .tab-header,
@@ -98,18 +102,35 @@
     margin: 10px 0 0 0;
 }
 
-.xblock--drag-and-drop--editor .target-image-form input,
-.xblock--drag-and-drop--editor .target-image-form textarea {
+.xblock--drag-and-drop--editor .target-image-form input {
     width: 50%;
+}
+.xblock--drag-and-drop--editor .target-image-form textarea {
+    width: 97%;
 }
 
 .xblock--drag-and-drop--editor .target-image-form textarea {
     display: block;
 }
 
+.xblock--drag-and-drop--editor input,
+.xblock--drag-and-drop--editor textarea {
+    box-sizing: border-box;
+    font-size: 14px;
+    background: #fff;
+    box-shadow: none;
+    padding: 6px 8px;
+    border: 1px solid #b2b2b2;
+    color: #4c4c4c;
+}
+
 .xblock--drag-and-drop--editor label > span {
     display: inline-block;
     margin-bottom: 0.25em;
+}
+
+.xblock--drag-and-drop--editor label.checkbox-label {
+    font-size: 14px;
 }
 
 /* Main Tab */
@@ -151,29 +172,36 @@
   max-width: 100%;
 }
 
+.xblock--drag-and-drop--editor .zones-form .zone-row {
+    background-color: #b1d9f1;
+    padding: 1rem;
+    margin-bottom: 2rem;
+}
+
 .xblock--drag-and-drop--editor .zones-form .zone-row label {
     display: block;
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row label > span {
     display: inline-block;
-    width: 6em;
+    font-size: 14px;
+    min-width: 8rem;
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row label > input {
-    width: 60%;
+    width: 66%;
     margin: 0 0 5px;
     line-height: 2.664rem;  /* .title gets line-height from a Studio rule that does not apply to .description;
                                here we make sure that both input fields get the same value for line-height */
 }
 
-.xblock--drag-and-drop--editor .zones-form .zone-row .alignment {
-    margin-bottom: 15px;
+.xblock--drag-and-drop--editor .zones-form .zone-row .layout {
+    margin: 2rem 0;
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout label {
     display: inline-block;
-    width: 40%;
+    width: 45%;
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout .zone-size,
@@ -183,14 +211,19 @@
     line-height: inherit;
 }
 
+.xblock--drag-and-drop--editor .zones-form .zone-row .alignment {
+    margin-bottom: 15px;
+}
+
+
 .xblock--drag-and-drop--editor .feedback-form textarea {
     width: 99%;
     height: 128px;
 }
 
 .xblock--drag-and-drop--editor .form-help {
-    margin-top: 5px;
-    font-size: small;
+    margin: 0.5rem 0 1rem;
+    font-size: 12px;
 }
 
 .xblock--drag-and-drop--editor .item-styles-form,
@@ -199,14 +232,9 @@
 }
 
 .xblock--drag-and-drop--editor .items-form .item {
-    background-color: #8fcaec;
-    padding: 10px 0 1px;
-    margin: 15px 0;
-}
-
-.xblock--drag-and-drop--editor .items-form label,
-.xblock--drag-and-drop--editor .items-form .h3 {
-    margin: 0 1%;
+    background-color: #b1d9f1;
+    padding: 2rem;
+    margin-bottom: 2rem;
 }
 
 .xblock--drag-and-drop--editor .items-form select {
@@ -220,7 +248,6 @@
 .xblock--drag-and-drop--editor .items-form .item-text,
 .xblock--drag-and-drop--editor .items-form .item-image-url {
     width: 50%;
-    margin: 0 1%;
 }
 
 .xblock--drag-and-drop--editor .items-form .item-width {
@@ -235,16 +262,21 @@
     text-align: left;
 }
 
-.xblock--drag-and-drop--editor .items-form .row {
-    margin-bottom: 20px;
-}
 .xblock--drag-and-drop--editor .items-form .row.advanced {
     display: none;
 }
 .xblock--drag-and-drop--editor .items-form .row.advanced-link {
-    cursor: pointer;
-    padding-left: 1em;
-    font-size: 80%;
+    font-size: 12px;
+    margin-top: 2em;
+}
+.xblock--drag-and-drop--editor .items-form .row.advanced-link button {
+    background: none;
+    border: none;
+    color: #4c4c4c;
+}
+.xblock--drag-and-drop--editor .items-form .row.advanced-link button:before {
+    content: '\25B6';
+    margin-right: 0.5em;
 }
 .xblock--drag-and-drop-editor .items-form .zone-checkbox-row {
     margin-bottom: 0px;
@@ -269,22 +301,11 @@
     opacity: 0.5;
 }
 
-.xblock--drag-and-drop--editor .add-element {
-    text-decoration: none;
-    color: #1d5280;
-}
-
-.xblock--drag-and-drop--editor .remove-zone {
-    cursor: pointer;
-    float: right;
-    margin-top: 2px;
-    margin-right: 16px;
-}
-
+.xblock--drag-and-drop--editor .remove-zone,
 .xblock--drag-and-drop--editor .remove-item {
-    cursor: pointer;
     float: right;
-    margin-right: 16px;
+    padding: 3px;
+    border-radius: 12px;
 }
 
 .xblock--drag-and-drop--editor .icon {
@@ -292,9 +313,12 @@
     height: 14px;
     border-radius: 7px;
     background-color: #1d5280;
-    position: relative;
-    float: left;
-    margin: 0 5px 0 0;
+    display: inline-block;
+}
+
+.xblock--drag-and-drop--editor .remove-zone .icon,
+.xblock--drag-and-drop--editor .remove-item .icon {
+    display: block;
 }
 
 .xblock--drag-and-drop--editor .add-zone:hover,
@@ -363,13 +387,4 @@
     -webkit-transform: rotate(45deg);
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
-}
-
-.xblock--drag-and-drop--editor .remove-item .icon.remove {
-    background-color: #fff;
-    color: #0072a7;  /* Override default color from Studio to ensure contrast is large enough */
-}
-.xblock--drag-and-drop--editor .remove-item .icon.remove:before,
-.xblock--drag-and-drop--editor .remove-item .icon.remove:after {
-    background-color: #1d5280;
 }

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -79,11 +79,6 @@
     font-size: 100%;
 }
 
-.xblock--drag-and-drop--editor .tab .nested-input {
-    display: block;
-    margin-top: 8px;
-}
-
 .xblock--drag-and-drop--editor .tab-header,
 .xblock--drag-and-drop--editor .tab-content,
 .xblock--drag-and-drop--editor .tab-footer {
@@ -106,6 +101,25 @@
 .xblock--drag-and-drop--editor .target-image-form input,
 .xblock--drag-and-drop--editor .target-image-form textarea {
     width: 50%;
+}
+
+.xblock--drag-and-drop--editor .target-image-form textarea {
+    display: block;
+}
+
+.xblock--drag-and-drop--editor label > span {
+    display: inline-block;
+    margin-bottom: 0.25em;
+}
+
+/* Main Tab */
+.xblock--drag-and-drop--editor .feedback-tab input,
+.xblock--drag-and-drop--editor .feedback-tab select {
+    display: block;
+}
+
+.xblock--drag-and-drop--editor .feedback-tab input[type=checkbox] {
+    display: inline-block;
 }
 
 /* Zones Tab */
@@ -138,11 +152,15 @@
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row label {
-    display: inline-block;
-    width: 18%;
+    display: block;
 }
 
-.xblock--drag-and-drop--editor .zones-form .zone-row > input {
+.xblock--drag-and-drop--editor .zones-form .zone-row label > span {
+    display: inline-block;
+    width: 6em;
+}
+
+.xblock--drag-and-drop--editor .zones-form .zone-row label > input {
     width: 60%;
     margin: 0 0 5px;
     line-height: 2.664rem;  /* .title gets line-height from a Studio rule that does not apply to .description;
@@ -153,11 +171,16 @@
     margin-bottom: 15px;
 }
 
+.xblock--drag-and-drop--editor .zones-form .zone-row .layout label {
+    display: inline-block;
+    width: 40%;
+}
 
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout .size,
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout .coord {
-    width: 15%;
+    width: 35%;
     margin: 0 19px 5px 0;
+    line-height: inherit;
 }
 
 .xblock--drag-and-drop--editor .feedback-form textarea {
@@ -206,7 +229,6 @@
 
 .xblock--drag-and-drop--editor .items-form textarea {
     width: 97%;
-    margin: 0 1%;
 }
 
 .xblock--drag-and-drop--editor .items-form .zone-checkbox-label {

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -179,7 +179,7 @@
 }
 
 .xblock--drag-and-drop--editor .zones-form .zone-row label > input {
-    width: 66%;
+    width: 63%;
     margin: 0 0 5px;
     line-height: 2.664rem;  /* .title gets line-height from a Studio rule that does not apply to .description;
                                here we make sure that both input fields get the same value for line-height */

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -176,8 +176,8 @@
     width: 40%;
 }
 
-.xblock--drag-and-drop--editor .zones-form .zone-row .layout .size,
-.xblock--drag-and-drop--editor .zones-form .zone-row .layout .coord {
+.xblock--drag-and-drop--editor .zones-form .zone-row .layout .zone-size,
+.xblock--drag-and-drop--editor .zones-form .zone-row .layout .zone-coord {
     width: 35%;
     margin: 0 19px 5px 0;
     line-height: inherit;

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -61,8 +61,7 @@
     position: relative;
 }
 
-.xblock--drag-and-drop--editor .tab::after,
-.xblock--drag-and-drop--editor .tab-footer::after {
+.xblock--drag-and-drop--editor .tab::after {
   content: "";
   display: table;
   clear: both;
@@ -84,17 +83,9 @@
 }
 
 .xblock--drag-and-drop--editor .tab-header,
-.xblock--drag-and-drop--editor .tab-content,
-.xblock--drag-and-drop--editor .tab-footer {
+.xblock--drag-and-drop--editor .tab-content {
     width: 96%;
     margin: 2%;
-}
-
-.xblock--drag-and-drop--editor .tab-footer {
-    height: 25px;
-    position: relative;
-    display: block;
-    float: left;
 }
 
 .xblock--drag-and-drop--editor .items {
@@ -157,7 +148,6 @@
   width: 40%;
   max-width: 50%;
   min-width: 330px;
-  margin-right: 15px;
 }
 
 .xblock--drag-and-drop--editor .zones-tab .tab-content .target {
@@ -207,7 +197,6 @@
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout .zone-size,
 .xblock--drag-and-drop--editor .zones-form .zone-row .layout .zone-coord {
     width: 35%;
-    margin: 0 19px 5px 0;
     line-height: inherit;
 }
 
@@ -258,10 +247,6 @@
     width: 97%;
 }
 
-.xblock--drag-and-drop--editor .items-form .zone-checkbox-label {
-    text-align: left;
-}
-
 .xblock--drag-and-drop--editor .items-form .row.advanced {
     display: none;
 }
@@ -278,6 +263,12 @@
     content: '\25B6';
     margin-right: 0.5em;
 }
+.rtl .xblock--drag-and-drop--editor .items-form .row.advanced-link button:before {
+    content: '\25C0';
+    margin-left: 0.5em;
+    margin-right: 0;
+}
+
 .xblock--drag-and-drop-editor .items-form .zone-checkbox-row {
     margin-bottom: 0px;
 }
@@ -291,14 +282,10 @@
     padding: 5px 10px;
 }
 
-.xblock--drag-and-drop--editor .btn:hover {
-    opacity: 0.8;
-    cursor: pointer;
-}
-
+.xblock--drag-and-drop--editor .btn:hover,
 .xblock--drag-and-drop--editor .btn:focus {
-    outline: none;
-    opacity: 0.5;
+    background-color: #296ba5;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.5);
 }
 
 .xblock--drag-and-drop--editor .remove-zone,
@@ -307,25 +294,21 @@
     padding: 3px;
     border-radius: 12px;
 }
+.rtl .xblock--drag-and-drop--editor .remove-zone,
+.rtl .xblock--drag-and-drop--editor .remove-item {
+    float: left;
+}
 
 .xblock--drag-and-drop--editor .icon {
     width: 14px;
     height: 14px;
     border-radius: 7px;
-    background-color: #1d5280;
     display: inline-block;
 }
 
 .xblock--drag-and-drop--editor .remove-zone .icon,
 .xblock--drag-and-drop--editor .remove-item .icon {
     display: block;
-}
-
-.xblock--drag-and-drop--editor .add-zone:hover,
-.xblock--drag-and-drop--editor .add-zone:hover .icon,
-.xblock--drag-and-drop--editor .remove-zone:hover,
-.xblock--drag-and-drop--editor .remove-zone:hover .icon {
-    opacity: 0.7;
 }
 
 .xblock--drag-and-drop--editor .tab .field-error {

--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -165,9 +165,7 @@
     height: 128px;
 }
 
-.xblock--drag-and-drop--editor .zones-form .zones-form-help,
-.xblock--drag-and-drop--editor .target-image-form .target-image-form-help,
-.xblock--drag-and-drop--editor .item-styles-form .item-styles-form-help {
+.xblock--drag-and-drop--editor .form-help {
     margin-top: 5px;
     font-size: small;
 }
@@ -222,6 +220,7 @@
     display: none;
 }
 .xblock--drag-and-drop--editor .items-form .row.advanced-link {
+    cursor: pointer;
     padding-left: 1em;
     font-size: 80%;
 }
@@ -254,14 +253,15 @@
 }
 
 .xblock--drag-and-drop--editor .remove-zone {
+    cursor: pointer;
     float: right;
     margin-top: 2px;
     margin-right: 16px;
 }
 
 .xblock--drag-and-drop--editor .remove-item {
+    cursor: pointer;
     float: right;
-    display: inline-block;
     margin-right: 16px;
 }
 

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -181,6 +181,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                         .on('click', '.add-zone', function(e) {
                             e.preventDefault();
                             _fn.build.form.zone.add();
+                            // Set focus to first field of the new zone.
+                            $('.zones-form .zone-row:last input[type=text]:first', element).select().focus();
                         })
                         .on('click', '.remove-zone', _fn.build.form.zone.remove)
                         .on('input', '.zone-row input', _fn.build.form.zone.changedInputHandler)
@@ -220,6 +222,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                         .on('click', '.add-item', function(e) {
                             e.preventDefault();
                             _fn.build.form.item.add();
+                            // Set focus to first field of the new item.
+                            $('.items-form .item:last input[type=text]:first', element).select().focus();
                         })
                         .on('click', '.remove-item', _fn.build.form.item.remove)
                         .on('click', '.advanced-link button', _fn.build.form.item.showAdvancedSettings)

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -137,6 +137,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                         $fbkTab.addClass('hidden');
                         $zoneTab.removeClass('hidden');
                         self.scrollToTop();
+                        $zoneTab.find('input:first').focus();
 
                         $(this).one('click', function loadThirdTab(e) {
                             // $zoneTab -> $itemTab
@@ -157,6 +158,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             $zoneTab.addClass('hidden');
                             $itemTab.removeClass('hidden');
                             self.scrollToTop();
+                            $itemTab.find('input:first').focus();
 
                             $(this).addClass('hidden');
                             $('.save-button', element).parent()

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -184,7 +184,6 @@ function DragAndDropEditBlock(runtime, element, params) {
 
                     $zoneTab
                         .on('click', '.add-zone', function(e) {
-                            e.preventDefault();
                             _fn.build.form.zone.add();
                             // Set focus to first field of the new zone.
                             $('.zones-form .zone-row:last input[type=text]:first', element).select();
@@ -193,8 +192,6 @@ function DragAndDropEditBlock(runtime, element, params) {
                         .on('input', '.zone-row input', _fn.build.form.zone.changedInputHandler)
                         .on('change', '.align-select', _fn.build.form.zone.changedInputHandler)
                         .on('click', '.target-image-form button', function(e) {
-                            e.preventDefault();
-
                             var new_img_url = $.trim($('.target-image-form .background-url', element).val());
                             if (new_img_url) {
                                 // We may need to 'expand' the URL before it will be valid.
@@ -225,7 +222,6 @@ function DragAndDropEditBlock(runtime, element, params) {
 
                     $itemTab
                         .on('click', '.add-item', function(e) {
-                            e.preventDefault();
                             _fn.build.form.item.add();
                             // Set focus to first field of the new item.
                             $('.items-form .item:last input[type=text]:first', element).select();
@@ -308,7 +304,6 @@ function DragAndDropEditBlock(runtime, element, params) {
                                 uid = String($el.data('uid')),  // cast to string since UID must be string but .data() converts data-uid="5" to 5
                                 array_index;
 
-                            e.preventDefault();
                             $el.detach();
 
                             // Find the uid of the zone in the array and remove it.
@@ -447,7 +442,6 @@ function DragAndDropEditBlock(runtime, element, params) {
                         remove: function(e) {
                             var $el = $(e.currentTarget).closest('.item');
 
-                            e.preventDefault();
                             $el.detach();
 
                             _fn.build.form.item.count--;
@@ -471,7 +465,6 @@ function DragAndDropEditBlock(runtime, element, params) {
                             }
                         },
                         showAdvancedSettings: function(e) {
-                            e.preventDefault();
                             var $el = $(e.currentTarget).closest('.item');
                             $el.find('.row.advanced').show();
                             $el.find('.row.advanced-link').hide();

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -354,19 +354,19 @@ function DragAndDropEditBlock(runtime, element, params) {
                             var $changedInput = $(ev.currentTarget);
                             var $row = $changedInput.closest('.zone-row');
                             var record = _fn.build.form.zone.getZoneObjByUID(String($row.data('uid')));
-                            if ($changedInput.hasClass('title')) {
+                            if ($changedInput.hasClass('zone-title')) {
                                 record.title = $changedInput.val();
-                            } else if ($changedInput.hasClass('width')) {
+                            } else if ($changedInput.hasClass('zone-width')) {
                                 record.width = $changedInput.val();
-                            } else if ($changedInput.hasClass('description')) {
+                            } else if ($changedInput.hasClass('zone-description')) {
                                 record.description = $changedInput.val();
-                            } else if ($changedInput.hasClass('height')) {
+                            } else if ($changedInput.hasClass('zone-height')) {
                                 record.height = $changedInput.val();
-                            } else if ($changedInput.hasClass('x')) {
+                            } else if ($changedInput.hasClass('zone-x')) {
                                 record.x = $changedInput.val();
-                            } else if ($changedInput.hasClass('y')) {
+                            } else if ($changedInput.hasClass('zone-y')) {
                                 record.y = $changedInput.val();
-                            } else if ($changedInput.hasClass('align-select')) {
+                            } else if ($changedInput.hasClass('zone-align-select')) {
                                 record.align = $changedInput.val();
                             }
                             _fn.build.form.zone.renderZonesPreview();

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -29,10 +29,10 @@ function DragAndDropEditBlock(runtime, element, params) {
             tpl: {
                 init: function() {
                     _fn.tpl = {
-                        zoneInput: Handlebars.compile($("#zone-input-tpl", element).html()),
-                        zoneElement: Handlebars.compile($("#zone-element-tpl", element).html()),
-                        zoneCheckbox: Handlebars.compile($("#zone-checkbox-tpl", element).html()),
-                        itemInput: Handlebars.compile($("#item-input-tpl", element).html()),
+                        zoneInput: Handlebars.compile($(".zone-input-tpl", element).html()),
+                        zoneElement: Handlebars.compile($(".zone-element-tpl", element).html()),
+                        zoneCheckbox: Handlebars.compile($(".zone-checkbox-tpl", element).html()),
+                        itemInput: Handlebars.compile($(".item-input-tpl", element).html()),
                     };
                 }
             },
@@ -66,7 +66,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                     _fn.build.clickHandlers();
 
                     // Hide settings that are specific to assessment mode
-                    _fn.build.$el.feedback.form.find('#problem-mode').trigger('change');
+                    _fn.build.$el.feedback.form.find('.problem-mode').trigger('change');
                 },
 
                 validate: function() {
@@ -120,8 +120,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                         }
 
                         // Set the target image and bind its event handler:
-                        $('.target-image-form #background-url', element).val(_fn.data.targetImg);
-                        $('.target-image-form #background-description', element).val(_fn.data.targetImgDescription);
+                        $('.target-image-form .background-url', element).val(_fn.data.targetImg);
+                        $('.target-image-form .background-description', element).val(_fn.data.targetImgDescription);
                         _fn.build.$el.targetImage.load(_fn.build.form.zone.imageLoaded);
                         _fn.build.$el.targetImage.attr('src', params.target_img_expanded_url);
                         _fn.build.$el.targetImage.attr('alt', _fn.data.targetImgDescription);
@@ -175,7 +175,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                     });
 
                     $fbkTab
-                        .on('change', '#problem-mode', _fn.build.form.problem.toggleAssessmentSettings);
+                        .on('change', '.problem-mode', _fn.build.form.problem.toggleAssessmentSettings);
 
                     $zoneTab
                         .on('click', '.add-zone', function(e) {
@@ -188,7 +188,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                         .on('click', '.target-image-form button', function(e) {
                             e.preventDefault();
 
-                            var new_img_url = $.trim($('.target-image-form #background-url', element).val());
+                            var new_img_url = $.trim($('.target-image-form .background-url', element).val());
                             if (new_img_url) {
                                 // We may need to 'expand' the URL before it will be valid.
                                 // e.g. '/static/blah.png' becomes '/asset-v1:course+id/blah.png'
@@ -202,9 +202,9 @@ function DragAndDropEditBlock(runtime, element, params) {
                             }
                             _fn.data.targetImg = new_img_url;
                         })
-                        .on('input', '.target-image-form #background-description', function(e) {
+                        .on('input', '.target-image-form .background-description', function(e) {
                             var new_description = $.trim(
-                                $('.target-image-form #background-description', element).val()
+                                $('.target-image-form .background-description', element).val()
                             );
                             _fn.build.$el.targetImage.attr('alt', new_description);
                             _fn.data.targetImgDescription = new_description;
@@ -230,8 +230,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                         toggleAssessmentSettings: function(e) {
                             e.preventDefault();
                             var $modeSetting = $(e.currentTarget),
-                                $problemForm = $modeSetting.parent('form'),
-                                $assessmentSettings = $problemForm.find('.setting.assessment');
+                                $problemForm = $modeSetting.closest('form'),
+                                $assessmentSettings = $problemForm.find('.assessment-setting');
                             if ($modeSetting.val() === 'assessment') {
                                 $assessmentSettings.show();
                             } else {
@@ -394,8 +394,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                     },
                     feedback: function($form) {
                         _fn.data.feedback = {
-                            start: $form.find('#intro-feedback').val(),
-                            finish: $form.find('#final-feedback').val()
+                            start: $form.find('.intro-feedback').val(),
+                            finish: $form.find('.final-feedback').val()
                         };
                     },
                     item: {
@@ -505,15 +505,15 @@ function DragAndDropEditBlock(runtime, element, params) {
                         _fn.data.zones = _fn.build.form.zone.zoneObjects;
 
                         var data = {
-                            'display_name': $element.find('#display-name').val(),
-                            'mode': $element.find("#problem-mode").val(),
+                            'display_name': $element.find('.display-name').val(),
+                            'mode': $element.find(".problem-mode").val(),
                             'max_attempts': $element.find(".max-attempts").val(),
                             'show_title': $element.find('.show-title').is(':checked'),
-                            'weight': $element.find('#weight').val(),
-                            'problem_text': $element.find('#problem-text').val(),
+                            'weight': $element.find('.weight').val(),
+                            'problem_text': $element.find('.problem-text').val(),
                             'show_problem_header': $element.find('.show-problem-header').is(':checked'),
-                            'item_background_color': $element.find('#item-background-color').val(),
-                            'item_text_color': $element.find('#item-text-color').val(),
+                            'item_background_color': $element.find('.item-background-color').val(),
+                            'item_text_color': $element.find('.item-text-color').val(),
                             'data': _fn.data,
                         };
 

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -67,6 +67,9 @@ function DragAndDropEditBlock(runtime, element, params) {
 
                     // Hide settings that are specific to assessment mode
                     _fn.build.$el.feedback.form.find('.problem-mode').trigger('change');
+
+                    // Set focus on first input field.
+                    $element.find('input:first').select();
                 },
 
                 validate: function() {
@@ -137,7 +140,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                         $fbkTab.addClass('hidden');
                         $zoneTab.removeClass('hidden');
                         self.scrollToTop();
-                        $zoneTab.find('input:first').focus();
+                        $zoneTab.find('input:first').select();
 
                         $(this).one('click', function loadThirdTab(e) {
                             // $zoneTab -> $itemTab
@@ -158,7 +161,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             $zoneTab.addClass('hidden');
                             $itemTab.removeClass('hidden');
                             self.scrollToTop();
-                            $itemTab.find('input:first').focus();
+                            $itemTab.find('input:first').select();
 
                             $(this).addClass('hidden');
                             $('.save-button', element).parent()
@@ -184,7 +187,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             e.preventDefault();
                             _fn.build.form.zone.add();
                             // Set focus to first field of the new zone.
-                            $('.zones-form .zone-row:last input[type=text]:first', element).select().focus();
+                            $('.zones-form .zone-row:last input[type=text]:first', element).select();
                         })
                         .on('click', '.remove-zone', _fn.build.form.zone.remove)
                         .on('input', '.zone-row input', _fn.build.form.zone.changedInputHandler)
@@ -225,7 +228,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             e.preventDefault();
                             _fn.build.form.item.add();
                             // Set focus to first field of the new item.
-                            $('.items-form .item:last input[type=text]:first', element).select().focus();
+                            $('.items-form .item:last input[type=text]:first', element).select();
                         })
                         .on('click', '.remove-item', _fn.build.form.item.remove)
                         .on('click', '.advanced-link button', _fn.build.form.item.showAdvancedSettings)

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -222,7 +222,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             _fn.build.form.item.add();
                         })
                         .on('click', '.remove-item', _fn.build.form.item.remove)
-                        .on('click', '.advanced-link a', _fn.build.form.item.showAdvancedSettings)
+                        .on('click', '.advanced-link button', _fn.build.form.item.showAdvancedSettings)
                         .on('input', '.item-image-url', _fn.build.form.item.imageURLChanged);
                 },
                 form: {
@@ -430,7 +430,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                             }
                             ctx.checkboxes = _fn.build.form.createCheckboxes(ctx.zones);
 
-                            _fn.build.form.item.count++;
+                            ctx.index = _fn.build.form.item.count++;
                             $form.append(tpl(ctx));
                             _fn.build.form.item.enableDelete();
 

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -12,45 +12,53 @@
 
             <section class="tab-content">
                 <form class="feedback-form">
-                    <label class="h3" for="display-name">{% trans "Problem title" %}</label>
+                    <label class="h3" for="display-name">{% trans self.fields.display_name.display_name %}</label>
                     <input id="display-name" value="{{ self.display_name }}" />
                     <label title="{{ help_texts.show_title }}">
                       <input class="show-title" type="checkbox"
                         {% if self.show_title %}checked="checked"{% endif %}>
-                      {% trans "Show title" %}
+                      {% trans self.fields.show_title.display_name %}
                       <span class="sr">{{ help_texts.show_title }}</span>
                     </label>
 
-                    <label class="h3" for="problem-mode" title="{{ help_texts.mode }}">{% trans "Problem mode" %}</label>
-                    <select id="problem-mode">
+                    <label class="h3" for="problem-mode">{% trans self.fields.mode.display_name %}</label>
+                    <select id="problem-mode" aria-describedby="problem-mode-description">
                         {% for field_value in field_values.mode %}
                             <option value="{{ field_value.value }}" {% if self.mode == field_value.value %}selected{% endif %}>
                                 {{ field_value.display_name }}
                             </option>
                         {% endfor %}
                     </select>
-                    <span class="sr">{{ help_texts.mode }}</span>
+                    <div id="problem-mode-description" class="form-help">
+                      {{ help_texts.mode }}
+                    </div>
 
-                    <label class="h3 setting assessment" title="{{ help_texts.max_attempts }}">
-                      {% trans "Maximum attempts" %}
+                    <label class="h3 setting assessment">
+                      {% trans self.fields.max_attempts.display_name %}
                       <input class="nested-input max-attempts"
                              type="number"
                              min="1"
                              step="1"
+                             aria-describedby="max-attempts-description"
                              {% if self.max_attempts %}value="{{ self.max_attempts }}"{% endif %} />
                     </label>
+                    <div id="max-attempts-description" class="form-help">
+                      {{ help_texts.max_attempts }}
+                    </div>
 
-                    <label class="h3" for="weight">{% trans "Maximum score" %}</label>
+                    <label class="h3" for="weight">{% trans self.fields.weight.display_name %}</label>
                     <input id="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
 
-                    <label class="h3" for="problem-text">{% trans "Problem text" %}</label>
+                    <label class="h3" for="problem-text">{% trans self.fields.question_text.display_name %}</label>
                     <textarea id="problem-text">{{ self.question_text }}</textarea>
-                    <label title="{{ help_texts.show_question_header }}">
-                      <input class="show-problem-header" type="checkbox"
+                    <label>
+                      <input class="show-problem-header" type="checkbox" aria-describedby="show-problem-header-description"
                         {% if self.show_question_header %}checked="checked"{% endif %}>
-                      {% trans 'Show "Problem" heading' %}
-                      <span class="sr">{{ help_texts.show_question_header }}</span>
+                      {% trans self.fields.show_question_header.display_name %}
                     </label>
+                    <div id="show-problem-header-description" class="form-help">
+                      {{ help_texts.show_question_header }}
+                    </div>
 
                     <label class="h3" for="intro-feedback">{% trans "Introductory Feedback" %}</label>
                     <textarea id="intro-feedback">{{ self.data.feedback.start }}</textarea>
@@ -75,7 +83,7 @@
                     <label class="h3" for="background-description">{% trans "Background description" %}</label>
                     <textarea required id="background-description"
                               aria-describedby="background-description-description"></textarea>
-                    <div id="background-description-description" class="target-image-form-help">
+                    <div id="background-description-description" class="form-help">
                         {% blocktrans %}
                             Please provide a description of the image for non-visual users.
                             The description should provide sufficient information to allow anyone
@@ -117,20 +125,20 @@
             </header>
             <section class="tab-content">
                 <form class="item-styles-form">
-                    <label class="h3" for="item-background-color">{% trans "Background color" %}</label>
+                    <label class="h3" for="item-background-color">{% trans self.fields.item_background_color.display_name %}</label>
                     <input id="item-background-color"
                            placeholder="e.g. blue or #0000ff"
-                           value="{{ self.item_background_color}}"
+                           value="{{ self.item_background_color }}"
                            aria-describedby="item-background-color-description">
-                    <div id="item-background-color-description" class="item-styles-form-help">
+                    <div id="item-background-color-description" class="form-help">
                       {{ help_texts.item_background_color }}
                     </div>
-                    <label class="h3" for="item-text-color">{% trans "Text color" %}</label>
+                    <label class="h3" for="item-text-color">{% trans self.fields.item_text_color.display_name %}</label>
                     <input id="item-text-color"
                            placeholder="e.g. white or #ffffff"
                            value="{{ self.item_text_color}}"
                            aria-describedby="item-text-color-description">
-                    <div id="item-text-color-description" class="item-styles-form-help">
+                    <div id="item-text-color-description" class="form-help">
                       {{ help_texts.item_text_color }}
                     </div>
                 </form>

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -12,18 +12,18 @@
 
             <section class="tab-content">
                 <form class="feedback-form">
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.display_name.display_name %}</span>
                         <input class="display-name" value="{{ self.display_name }}" />
                     </label>
-                    <label title="{% trans fields.show_title.help %}">
+                    <label class="checkbox-label" title="{% trans fields.show_title.help %}">
                       <input class="show-title" type="checkbox"
                         {% if self.show_title %}checked="checked"{% endif %}>
                       {% trans fields.show_title.display_name %}
                       <span class="sr">{% trans fields.show_title.help %}</span>
                     </label>
 
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.mode.display_name %}</span>
                         <select class="problem-mode" aria-describedby="problem-mode-description-{{id_suffix}}">
                             {% for field_value in fields.mode.values %}
@@ -37,8 +37,8 @@
                       {% trans fields.mode.help %}
                     </div>
 
-                    <label class="h3 assessment-setting">
-                      {% trans fields.max_attempts.display_name %}
+                    <label class="h4 assessment-setting">
+                      <span>{% trans fields.max_attempts.display_name %}</span>
                       <input class="max-attempts"
                              type="number"
                              min="1"
@@ -50,16 +50,16 @@
                       {% trans fields.max_attempts.help %}
                     </div>
 
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.weight.display_name %}</span>
                         <input class="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
                     </label>
 
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.question_text.display_name %}</span>
                         <textarea class="problem-text">{{ self.question_text }}</textarea>
                     </label>
-                    <label>
+                    <label class="checkbox-label">
                       <input class="show-problem-header"
                              type="checkbox"
                              aria-describedby="show-problem-header-description-{{id_suffix}}"
@@ -70,12 +70,12 @@
                       {% trans fields.show_question_header.help %}
                     </div>
 
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans "Introductory Feedback" %}</span>
                         <textarea class="intro-feedback">{{ self.data.feedback.start }}</textarea>
                     </label>
 
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans "Final Feedback" %}</span>
                         <textarea class="final-feedback">{{ self.data.feedback.finish }}</textarea>
                     </label>
@@ -89,16 +89,19 @@
             </header>
             <section class="tab-content">
                 <form class="target-image-form">
-                    <label class="h3" for="background-url-{{id_suffix}}">
+                    <label class="h4" for="background-url-{{id_suffix}}">
                         <span>{% trans "Background URL" %}</span>
                     </label>
                     <input class="background-url"
                            id="background-url-{{id_suffix}}"
                            type="text"
-                           placeholder="{% trans 'For example, http://example.com/background.png or /static/background.png' %}">
+                           aria-describedby="background-url-{{id_suffix}}" />
                     </label>
                     <button class="btn">{% trans "Change background" %}</button>
-                    <label class="h3">
+                    <div id="background-url-description-{{id_suffix}}" class="form-help">
+                        {% trans "For example, 'http://example.com/background.png' or '/static/background.png'." %}
+                    </div>
+                    <label class="h4">
                         <span>{% trans "Background description" %}</span>
                         <textarea required class="background-description"
                                   aria-describedby="background-description-description-{{id_suffix}}"></textarea>
@@ -114,25 +117,29 @@
             </section>
             <section class="tab-content">
                 <form class="display-labels-form">
-                    <h3>{% trans "Zone labels" %}</h3>
-                    <label>
-                        <span>{% trans "Display label names on the image" %}:</span>
+                    <h4>{% trans "Zone labels" %}</h4>
+                    <label class="checkbox-label">
                         <input name="display-labels" class="display-labels" type="checkbox" />
+                        <span>{% trans "Display label names on the image" %}</span>
                     </label>
                 </form>
                 <form class="display-borders-form">
-                    <h3>{% trans "Zone borders" %}</h3>
-                    <label>
-                        <span>{% trans "Display zone borders on the image" %}:</span>
+                    <h4>{% trans "Zone borders" %}</h4>
+                    <label class="checkbox-label">
                         <input name="display-borders" class="display-borders" type="checkbox" />
+                        <span>{% trans "Display zone borders on the image" %}</span>
                     </label>
                 </form>
             </section>
             <section class="tab-content">
+                <h4>{% trans "Zone definitions" %}</h4>
                 <div class="zone-editor">
                     <div class="controls">
                         <form class="zones-form"></form>
-                        <a href="#" class="add-zone add-element"><div class="icon add"></div>{% trans "Add a zone" %}</a>
+                        <button class="btn add-zone add-element">
+                            <span class="icon add"></span>
+                            {% trans "Add a zone" %}
+                        </button>
                     </div>
                     <div class="target">
                         <img class="target-img">
@@ -149,20 +156,18 @@
             </header>
             <section class="tab-content">
                 <form class="item-styles-form">
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.item_background_color.display_name %}</span>
                         <input class="item-background-color"
-                               placeholder="{% blocktrans with example1='blue' example2='#0000ff' %}e.g. {{example1}} or {{example2}}{% endblocktrans %}"
                                value="{{ self.item_background_color }}"
                                aria-describedby="item-background-color-description-{{id_suffix}}">
                     </label>
                     <div id="item-background-color-description-{{id_suffix}}" class="form-help">
                       {% trans fields.item_background_color.help %}
                     </div>
-                    <label class="h3">
+                    <label class="h4">
                         <span>{% trans fields.item_text_color.display_name %}</span>
                         <input class="item-text-color"
-                               placeholder="{% blocktrans with example1='white' example2='#ffffff' %}e.g. {{example1}} or {{example2}}{% endblocktrans %}"
                                value="{{ self.item_text_color}}"
                                aria-describedby="item-text-color-description-{{id_suffix}}">
                     </label>
@@ -172,11 +177,13 @@
                 </form>
             </section>
             <section class="tab-content">
+                <h4>{% trans "Item definitions" %}</h4>
                 <form class="items-form"></form>
+                <button class="btn add-item add-element">
+                    <span class="icon add"></span>
+                    {% trans "Add an item" %}
+                </button>
             </section>
-            <footer class="tab-footer">
-                <a href="#" class="add-item add-element"><div class="icon add"></div>{% trans "Add an item" %}</a>
-            </footer>
         </div>
 
     </section>

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -13,32 +13,32 @@
             <section class="tab-content">
                 <form class="feedback-form">
                     <label class="h3">
-                        <span>{% trans self.fields.display_name.display_name %}</span>
+                        <span>{% trans fields.display_name.display_name %}</span>
                         <input class="display-name" value="{{ self.display_name }}" />
                     </label>
-                    <label title="{{ help_texts.show_title }}">
+                    <label title="{% trans fields.show_title.help %}">
                       <input class="show-title" type="checkbox"
                         {% if self.show_title %}checked="checked"{% endif %}>
-                      {% trans self.fields.show_title.display_name %}
-                      <span class="sr">{{ help_texts.show_title }}</span>
+                      {% trans fields.show_title.display_name %}
+                      <span class="sr">{% trans fields.show_title.help %}</span>
                     </label>
 
                     <label class="h3">
-                        <span>{% trans self.fields.mode.display_name %}</span>
+                        <span>{% trans fields.mode.display_name %}</span>
                         <select class="problem-mode" aria-describedby="problem-mode-description-{{id_suffix}}">
-                            {% for field_value in field_values.mode %}
+                            {% for field_value in fields.mode.values %}
                                 <option value="{{ field_value.value }}" {% if self.mode == field_value.value %}selected{% endif %}>
-                                    {{ field_value.display_name }}
+                                    {% trans field_value.display_name %}
                                 </option>
                             {% endfor %}
                         </select>
                     </label>
                     <div id="problem-mode-description-{{id_suffix}}" class="form-help">
-                      {{ help_texts.mode }}
+                      {% trans fields.mode.help %}
                     </div>
 
                     <label class="h3 assessment-setting">
-                      {% trans self.fields.max_attempts.display_name %}
+                      {% trans fields.max_attempts.display_name %}
                       <input class="max-attempts"
                              type="number"
                              min="1"
@@ -47,16 +47,16 @@
                              {% if self.max_attempts %}value="{{ self.max_attempts }}"{% endif %} />
                     </label>
                     <div id="max-attempts-description-{{id_suffix}}" class="assessment-setting form-help">
-                      {{ help_texts.max_attempts }}
+                      {% trans fields.max_attempts.help %}
                     </div>
 
                     <label class="h3">
-                        <span>{% trans self.fields.weight.display_name %}</span>
+                        <span>{% trans fields.weight.display_name %}</span>
                         <input class="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
                     </label>
 
                     <label class="h3">
-                        <span>{% trans self.fields.question_text.display_name %}</span>
+                        <span>{% trans fields.question_text.display_name %}</span>
                         <textarea class="problem-text">{{ self.question_text }}</textarea>
                     </label>
                     <label>
@@ -64,10 +64,10 @@
                              type="checkbox"
                              aria-describedby="show-problem-header-description-{{id_suffix}}"
                         {% if self.show_question_header %}checked="checked"{% endif %}>
-                      {% trans self.fields.show_question_header.display_name %}
+                      {% trans fields.show_question_header.display_name %}
                     </label>
                     <div id="show-problem-header-description-{{id_suffix}}" class="form-help">
-                      {{ help_texts.show_question_header }}
+                      {% trans fields.show_question_header.help %}
                     </div>
 
                     <label class="h3">
@@ -150,24 +150,24 @@
             <section class="tab-content">
                 <form class="item-styles-form">
                     <label class="h3">
-                        <span>{% trans self.fields.item_background_color.display_name %}</span>
+                        <span>{% trans fields.item_background_color.display_name %}</span>
                         <input class="item-background-color"
-                               placeholder="e.g. blue or #0000ff"
+                               placeholder="{% blocktrans with example1='blue' example2='#0000ff' %}e.g. {{example1}} or {{example2}}{% endblocktrans %}"
                                value="{{ self.item_background_color }}"
                                aria-describedby="item-background-color-description-{{id_suffix}}">
                     </label>
                     <div id="item-background-color-description-{{id_suffix}}" class="form-help">
-                      {{ help_texts.item_background_color }}
+                      {% trans fields.item_background_color.help %}
                     </div>
                     <label class="h3">
-                        <span>{% trans self.fields.item_text_color.display_name %}</span>
+                        <span>{% trans fields.item_text_color.display_name %}</span>
                         <input class="item-text-color"
-                               placeholder="e.g. white or #ffffff"
+                               placeholder="{% blocktrans with example1='white' example2='#ffffff' %}e.g. {{example1}} or {{example2}}{% endblocktrans %}"
                                value="{{ self.item_text_color}}"
                                aria-describedby="item-text-color-description-{{id_suffix}}">
                     </label>
                     <div id="item-text-color-description-{{id_suffix}}" class="form-help">
-                      {{ help_texts.item_text_color }}
+                      {% trans fields.item_text_color.help %}
                     </div>
                 </form>
             </section>

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -12,8 +12,10 @@
 
             <section class="tab-content">
                 <form class="feedback-form">
-                    <label class="h3" for="display-name">{% trans self.fields.display_name.display_name %}</label>
-                    <input id="display-name" value="{{ self.display_name }}" />
+                    <label class="h3">
+                        <span>{% trans self.fields.display_name.display_name %}</span>
+                        <input class="display-name" value="{{ self.display_name }}" />
+                    </label>
                     <label title="{{ help_texts.show_title }}">
                       <input class="show-title" type="checkbox"
                         {% if self.show_title %}checked="checked"{% endif %}>
@@ -21,50 +23,62 @@
                       <span class="sr">{{ help_texts.show_title }}</span>
                     </label>
 
-                    <label class="h3" for="problem-mode">{% trans self.fields.mode.display_name %}</label>
-                    <select id="problem-mode" aria-describedby="problem-mode-description">
-                        {% for field_value in field_values.mode %}
-                            <option value="{{ field_value.value }}" {% if self.mode == field_value.value %}selected{% endif %}>
-                                {{ field_value.display_name }}
-                            </option>
-                        {% endfor %}
-                    </select>
-                    <div id="problem-mode-description" class="form-help">
+                    <label class="h3">
+                        <span>{% trans self.fields.mode.display_name %}</span>
+                        <select class="problem-mode" aria-describedby="problem-mode-description-{{id_suffix}}">
+                            {% for field_value in field_values.mode %}
+                                <option value="{{ field_value.value }}" {% if self.mode == field_value.value %}selected{% endif %}>
+                                    {{ field_value.display_name }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </label>
+                    <div id="problem-mode-description-{{id_suffix}}" class="form-help">
                       {{ help_texts.mode }}
                     </div>
 
-                    <label class="h3 setting assessment">
+                    <label class="h3 assessment-setting">
                       {% trans self.fields.max_attempts.display_name %}
-                      <input class="nested-input max-attempts"
+                      <input class="max-attempts"
                              type="number"
                              min="1"
                              step="1"
-                             aria-describedby="max-attempts-description"
+                             aria-describedby="max-attempts-description-{{id_suffix}}"
                              {% if self.max_attempts %}value="{{ self.max_attempts }}"{% endif %} />
                     </label>
-                    <div id="max-attempts-description" class="form-help">
+                    <div id="max-attempts-description-{{id_suffix}}" class="assessment-setting form-help">
                       {{ help_texts.max_attempts }}
                     </div>
 
-                    <label class="h3" for="weight">{% trans self.fields.weight.display_name %}</label>
-                    <input id="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
+                    <label class="h3">
+                        <span>{% trans self.fields.weight.display_name %}</span>
+                        <input class="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
+                    </label>
 
-                    <label class="h3" for="problem-text">{% trans self.fields.question_text.display_name %}</label>
-                    <textarea id="problem-text">{{ self.question_text }}</textarea>
+                    <label class="h3">
+                        <span>{% trans self.fields.question_text.display_name %}</span>
+                        <textarea class="problem-text">{{ self.question_text }}</textarea>
+                    </label>
                     <label>
-                      <input class="show-problem-header" type="checkbox" aria-describedby="show-problem-header-description"
+                      <input class="show-problem-header"
+                             type="checkbox"
+                             aria-describedby="show-problem-header-description-{{id_suffix}}"
                         {% if self.show_question_header %}checked="checked"{% endif %}>
                       {% trans self.fields.show_question_header.display_name %}
                     </label>
-                    <div id="show-problem-header-description" class="form-help">
+                    <div id="show-problem-header-description-{{id_suffix}}" class="form-help">
                       {{ help_texts.show_question_header }}
                     </div>
 
-                    <label class="h3" for="intro-feedback">{% trans "Introductory Feedback" %}</label>
-                    <textarea id="intro-feedback">{{ self.data.feedback.start }}</textarea>
+                    <label class="h3">
+                        <span>{% trans "Introductory Feedback" %}</span>
+                        <textarea class="intro-feedback">{{ self.data.feedback.start }}</textarea>
+                    </label>
 
-                    <label class="h3" for="final-feedback">{% trans "Final Feedback" %}</label>
-                    <textarea id="final-feedback">{{ self.data.feedback.finish }}</textarea>
+                    <label class="h3">
+                        <span>{% trans "Final Feedback" %}</span>
+                        <textarea class="final-feedback">{{ self.data.feedback.finish }}</textarea>
+                    </label>
                 </form>
             </section>
         </div>
@@ -75,15 +89,21 @@
             </header>
             <section class="tab-content">
                 <form class="target-image-form">
-                    <label class="h3" for="background-url">{% trans "Background URL" %}</label>
-                    <input id="background-url"
+                    <label class="h3" for="background-url-{{id_suffix}}">
+                        <span>{% trans "Background URL" %}</span>
+                    </label>
+                    <input class="background-url"
+                           id="background-url-{{id_suffix}}"
                            type="text"
                            placeholder="{% trans 'For example, http://example.com/background.png or /static/background.png' %}">
+                    </label>
                     <button class="btn">{% trans "Change background" %}</button>
-                    <label class="h3" for="background-description">{% trans "Background description" %}</label>
-                    <textarea required id="background-description"
-                              aria-describedby="background-description-description"></textarea>
-                    <div id="background-description-description" class="form-help">
+                    <label class="h3">
+                        <span>{% trans "Background description" %}</span>
+                        <textarea required class="background-description"
+                                  aria-describedby="background-description-description-{{id_suffix}}"></textarea>
+                    </label>
+                    <div id="background-description-description-{{id_suffix}}" class="form-help">
                         {% blocktrans %}
                             Please provide a description of the image for non-visual users.
                             The description should provide sufficient information to allow anyone
@@ -95,13 +115,17 @@
             <section class="tab-content">
                 <form class="display-labels-form">
                     <h3>{% trans "Zone labels" %}</h3>
-                    <label for="display-labels">{% trans "Display label names on the image" %}:</label>
-                    <input name="display-labels" id="display-labels" type="checkbox" />
+                    <label>
+                        <span>{% trans "Display label names on the image" %}:</span>
+                        <input name="display-labels" class="display-labels" type="checkbox" />
+                    </label>
                 </form>
                 <form class="display-borders-form">
                     <h3>{% trans "Zone borders" %}</h3>
-                    <label for="display-borders">{% trans "Display zone borders on the image" %}:</label>
-                    <input name="display-borders" id="display-borders" type="checkbox" />
+                    <label>
+                        <span>{% trans "Display zone borders on the image" %}:</span>
+                        <input name="display-borders" class="display-borders" type="checkbox" />
+                    </label>
                 </form>
             </section>
             <section class="tab-content">
@@ -125,20 +149,24 @@
             </header>
             <section class="tab-content">
                 <form class="item-styles-form">
-                    <label class="h3" for="item-background-color">{% trans self.fields.item_background_color.display_name %}</label>
-                    <input id="item-background-color"
-                           placeholder="e.g. blue or #0000ff"
-                           value="{{ self.item_background_color }}"
-                           aria-describedby="item-background-color-description">
-                    <div id="item-background-color-description" class="form-help">
+                    <label class="h3">
+                        <span>{% trans self.fields.item_background_color.display_name %}</span>
+                        <input class="item-background-color"
+                               placeholder="e.g. blue or #0000ff"
+                               value="{{ self.item_background_color }}"
+                               aria-describedby="item-background-color-description-{{id_suffix}}">
+                    </label>
+                    <div id="item-background-color-description-{{id_suffix}}" class="form-help">
                       {{ help_texts.item_background_color }}
                     </div>
-                    <label class="h3" for="item-text-color">{% trans self.fields.item_text_color.display_name %}</label>
-                    <input id="item-text-color"
-                           placeholder="e.g. white or #ffffff"
-                           value="{{ self.item_text_color}}"
-                           aria-describedby="item-text-color-description">
-                    <div id="item-text-color-description" class="form-help">
+                    <label class="h3">
+                        <span>{% trans self.fields.item_text_color.display_name %}</span>
+                        <input class="item-text-color"
+                               placeholder="e.g. white or #ffffff"
+                               value="{{ self.item_text_color}}"
+                               aria-describedby="item-text-color-description-{{id_suffix}}">
+                    </label>
+                    <div id="item-text-color-description-{{id_suffix}}" class="form-help">
                       {{ help_texts.item_text_color }}
                     </div>
                 </form>

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -137,7 +137,7 @@
                     <div class="controls">
                         <form class="zones-form"></form>
                         <button class="btn add-zone add-element">
-                            <span class="icon add"></span>
+                            <span class="icon add" aria-hidden="true"></span>
                             {% trans "Add a zone" %}
                         </button>
                     </div>
@@ -180,7 +180,7 @@
                 <h4>{% trans "Item definitions" %}</h4>
                 <form class="items-form"></form>
                 <button class="btn add-item add-element">
-                    <span class="icon add"></span>
+                    <span class="icon add" aria-hidden="true"></span>
                     {% trans "Add an item" %}
                 </button>
             </section>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -1,4 +1,4 @@
-<script id="zone-element-tpl" type="text/html">
+<script class="zone-element-tpl" type="text/html">
     <div class="zone" data-zone="{{ uid }}" style="
         top:{{ y_percent }}%;
         left:{{ x_percent }}%;
@@ -9,80 +9,84 @@
     </div>
 </script>
 
-<script id="zone-input-tpl" type="text/html">
+<script class="zone-input-tpl" type="text/html">
     <div class="zone-row" data-uid="{{zone.uid}}">
-        <!-- uid values from old versions of the block may contain spaces and other characters, so we use 'index' as an alternate unique ID here. -->
-        <label for="zone-{{index}}-title">{{i18n "Text"}}</label>
-        <input type="text"
-               id="zone-{{index}}-title"
-               class="title"
-               value="{{ zone.title }}"
-               required />
-        <a class="remove-zone hidden">
+        <a class="remove-zone hidden" title="{{i18n 'Remove zone'}}">
             <div class="icon remove"></div>
         </a>
-        <label for="zone-{{index}}-description">{{i18n "Description"}}</label>
-        <input type="text"
-               id="zone-{{index}}-description"
-               class="description"
-               value="{{ zone.description }}"
-               placeholder="{{i18n 'Describe this zone to non-visual users'}}"
-               required />
+        <label>
+            <span>{{i18n "Text"}}</span>
+            <input type="text"
+                   class="title"
+                   value="{{ zone.title }}"
+                   required />
+        </label>
+        <label>
+            <span>{{i18n "Description"}}</span>
+            <input type="text"
+                   class="description"
+                   value="{{ zone.description }}"
+                   placeholder="{{i18n 'Describe this zone to non-visual users'}}"
+                   required />
+        </label>
         <div class="layout">
-            <label for="zone-{{index}}-width">{{i18n "width"}}</label>
-            <input type="text"
-                   id="zone-{{index}}-width"
-                   class="size width"
-                   value="{{ zone.width }}" />
-            <label for="zone-{{index}}-height">{{i18n "height"}}</label>
-            <input type="text"
-                   id="zone-{{index}}-height"
-                   class="size height"
-                   value="{{ zone.height }}" />
+            <label>
+                <span>{{i18n "width"}}</span>
+                <input type="text"
+                       class="size width"
+                       value="{{ zone.width }}" />
+            </label>
+            <label>
+                <span>{{i18n "height"}}</span>
+                <input type="text"
+                       class="size height"
+                       value="{{ zone.height }}" />
+            </label>
             <br />
-            <label for="zone-{{index}}-x">x</label>
-            <input type="text"
-                   id="zone-{{index}}-x"
-                   class="coord x"
-                   value="{{ zone.x }}" />
-            <label for="zone-{{index}}-y">y</label>
-            <input type="text"
-                   id="zone-{{index}}-y"
-                   class="coord y"
-                   value="{{ zone.y }}" />
+            <label>
+                <span>x</span>
+                <input type="text"
+                       class="coord x"
+                       value="{{ zone.x }}" />
+            </label>
+            <label>
+                <span>y</span>
+                <input type="text"
+                       class="coord y"
+                       value="{{ zone.y }}" />
+            </label>
         </div>
         <div class="alignment">
-            <label for="zone-{{index}}-align">
-                {{i18n "Alignment"}}
+            <label>
+                <span>{{i18n "Alignment"}}</span>
+                <select class="align-select"
+                        aria-describedby="zone-align-description-{{zone.uid}}-{{id_suffix}}">
+                    <option value=""
+                        {{#ifeq zone.align ""}}selected{{/ifeq}}>
+                        {{i18n "none"}}
+                    </option>
+                    <option value="left"
+                        {{#ifeq zone.align "left"}}selected{{/ifeq}}>
+                        {{i18n "left"}}
+                    </option>
+                    <option value="center"
+                        {{#ifeq zone.align "center"}}selected{{/ifeq}}>
+                        {{i18n "center"}}
+                    </option>
+                    <option value="right"
+                        {{#ifeq zone.align "right"}}selected{{/ifeq}}>
+                        {{i18n "right"}}
+                    </option>
+                </select>
             </label>
-            <select id="zone-{{index}}-align"
-                    class="align-select"
-                    aria-describedby="zone-align-description">
-                <option value="" 
-                    {{#ifeq zone.align ""}}selected{{/ifeq}}>
-                    {{i18n "none"}}
-                </option>
-                <option value="left" 
-                    {{#ifeq zone.align "left"}}selected{{/ifeq}}>
-                    {{i18n "left"}}
-                </option>
-                <option value="center" 
-                    {{#ifeq zone.align "center"}}selected{{/ifeq}}>
-                    {{i18n "center"}}
-                </option>
-                <option value="right"
-                    {{#ifeq zone.align "right"}}selected{{/ifeq}}>
-                    {{i18n "right"}}
-                </option>
-            </select>
-            <div id="zone-align-description" class="zones-form-help">
+            <div id="zone-align-description-{{zone.uid}}-{{id_suffix}}" class="form-help">
                 {{i18n "Align dropped items to the left, center, or right.  Default is no alignment (items stay exactly where the user drops them)."}}
             </div>
         </div>
     </div>
 </script>
 
-<script id="zone-checkbox-tpl" type="text/html">
+<script class="zone-checkbox-tpl" type="text/html">
     <div class="zone-checkbox-row">
         <label>
             <input type="checkbox"
@@ -94,7 +98,7 @@
     </div>
 </script>
 
-<script id="item-input-tpl" type="text/html">
+<script class="item-input-tpl" type="text/html">
     <div class="item">
         <div class="row">
             <label class="h3">
@@ -126,32 +130,38 @@
             </label>
         </div>
         <div class="row">
-            <label class="h3" for="item-{{id}}-image-description">{{i18n "Image description (should provide sufficient information to place the item even if the image did not load)"}}</label>
-            <textarea id="item-{{id}}-image-description" {{#if imageURL}}required{{/if}}
-                      class="item-image-description">{{ imageDescription }}</textarea>
+            <label class="h3">
+                <span>{{i18n "Image description (should provide sufficient information to place the item even if the image did not load)"}}</span>
+                <textarea {{#if imageURL}}required{{/if}} class="item-image-description">{{ imageDescription }}</textarea>
+            </label>
         </div>
         <div class="row">
-            <label class="h3" for="item-{{id}}-success-feedback">{{i18n "Success Feedback"}}</label>
-            <textarea id="item-{{id}}-success-feedback"
-                      class="success-feedback">{{ feedback.correct }}</textarea>
+            <label class="h3">
+                <span>{{i18n "Success Feedback"}}</span>
+                <textarea class="success-feedback">{{ feedback.correct }}</textarea>
+            </label>
         </div>
         <div class="row">
-            <label class="h3" for="item-{{id}}-error-feedback">{{i18n "Error Feedback"}}</label>
-            <textarea id="item-{{id}}-error-feedback"
-                      class="error-feedback">{{ feedback.incorrect }}</textarea>
+            <label class="h3">
+                <span>{{i18n "Error Feedback"}}</span>
+                <textarea class="error-feedback">{{ feedback.incorrect }}</textarea>
+            </label>
         </div>
         <div class="row advanced-link">
             <a>{{i18n "Show advanced settings" }}</a>
         </div>
         <div class="row advanced">
             <label>
-                {{i18n "Preferred width as a percentage of the background image width (or blank for automatic width):"}}
+                <span>
+                  {{i18n "Preferred width as a percentage of the background image width (or blank for automatic width):"}}
+                </span>
                 <input type="number"
                        class="item-width"
                        value="{{ singleDecimalFloat widthPercent }}"
                        step="0.1"
                        min="1"
                        max="99" />%
+            </label>
         </div>
     </div>
 </script>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -10,10 +10,10 @@
 </script>
 
 <script class="zone-input-tpl" type="text/html">
-    <div class="zone-row" data-uid="{{zone.uid}}">
-        <a class="remove-zone hidden" title="{{i18n 'Remove zone'}}">
-            <div class="icon remove"></div>
-        </a>
+    <fieldset class="zone-row" data-uid="{{zone.uid}}">
+        <button type="button" class="btn remove-zone hidden" title="{{i18n 'Remove zone'}}">
+            <span class="icon remove"></span>
+        </button>
         <label>
             <span>{{i18n "Title"}}</span>
             <input type="text"
@@ -26,8 +26,11 @@
             <input type="text"
                    class="zone-description"
                    value="{{ zone.description }}"
-                   placeholder="{{i18n 'Describe this zone to non-visual users'}}"
+                   aria-describedby="zone-description-description-{{zone.uid}}-{{id_suffix}}"
                    required />
+            <div id="zone-description-description-{{zone.uid}}-{{id_suffix}}" class="form-help">
+                {{i18n "Describe this zone to non-visual users."}}
+            </div>
         </label>
         <div class="layout">
             <label>
@@ -83,12 +86,12 @@
                 {{i18n "Align dropped items to the left, center, or right.  Default is no alignment (items stay exactly where the user drops them)."}}
             </div>
         </div>
-    </div>
+    </fieldset>
 </script>
 
 <script class="zone-checkbox-tpl" type="text/html">
     <div class="zone-checkbox-row">
-        <label>
+        <label class="checkbox-label">
             <input type="checkbox"
                    value="{{ zoneUid }}"
                    class="zone-checkbox"
@@ -99,69 +102,77 @@
 </script>
 
 <script class="item-input-tpl" type="text/html">
-    <div class="item">
+    <fieldset class="item">
+        <button type="button" class="btn remove-item hidden" title="{{i18n 'Remove item'}}">
+            <span class="icon remove"></span>
+        </button>
         <div class="row">
-            <label class="h3">
+            <label class="h4">
                 {{i18n "Text"}}
                 <input type="text"
-                       placeholder="{{i18n 'Use text that is clear and descriptive of the item to be placed'}}"
+                       aria-describedby="item-text-description-{{index}}-{{id_suffix}}"
                        class="item-text"
                        value="{{ displayName }}" />
             </label>
-            <a class="remove-item hidden">
-                <div class="icon remove"></div>
-            </a>
+            <div id="item-text-description-{{index}}-{{id_suffix}}" class="form-help">
+                {{i18n "Use text that is clear and descriptive of the item to be placed."}}
+            </div>
         </div>
         <div class="row">
             <fieldset>
-                <legend class="h3">
+                <legend class="h4">
                     {{ i18n "Zones" }}
                 </legend>
                 {{ checkboxes }}
             </fieldset>
         </div>
         <div class="row">
-            <label class="h3">
+            <label class="h4">
                 {{i18n "Image URL (alternative to the text)"}}
                 <input type="text"
-                       placeholder="{{i18n 'For example, http://example.com/image.png or /static/image.png'}}"
+                       aria-describedby="item-image-url-description-{{index}}-{{id_suffix}}"
                        class="item-image-url"
                        value="{{ imageURL }}" />
             </label>
+            <div id="item-image-url-description-{{index}}-{{id_suffix}}" class="form-help">
+                {{i18n "For example, 'http://example.com/image.png' or '/static/image.png'."}}
+            </div>
         </div>
         <div class="row">
-            <label class="h3">
+            <label class="h4">
                 <span>{{i18n "Image description (should provide sufficient information to place the item even if the image did not load)"}}</span>
                 <textarea {{#if imageURL}}required{{/if}} class="item-image-description">{{ imageDescription }}</textarea>
             </label>
         </div>
         <div class="row">
-            <label class="h3">
+            <label class="h4">
                 <span>{{i18n "Success Feedback"}}</span>
                 <textarea class="success-feedback">{{ feedback.correct }}</textarea>
             </label>
         </div>
         <div class="row">
-            <label class="h3">
+            <label class="h4">
                 <span>{{i18n "Error Feedback"}}</span>
                 <textarea class="error-feedback">{{ feedback.incorrect }}</textarea>
             </label>
         </div>
         <div class="row advanced-link">
-            <a>{{i18n "Show advanced settings" }}</a>
+            <button type="button">{{i18n "Show advanced settings" }}</button>
         </div>
         <div class="row advanced">
-            <label>
-                <span>
-                  {{i18n "Preferred width as a percentage of the background image width (or blank for automatic width):"}}
-                </span>
+            <label class="h4">
+                <span>{{i18n "Preferred width"}}</span>
                 <input type="number"
                        class="item-width"
                        value="{{ singleDecimalFloat widthPercent }}"
+                       aria-describedby="item-width-description-{{index}}-{{id_suffix}}"
                        step="0.1"
                        min="1"
                        max="99" />%
             </label>
+            <div id="item-width-description-{{index}}-{{id_suffix}}" class="form-help">
+                {{i18n "Specify preferred width as percentage of the background image width. Leave blank for automatic width."}}
+            </div>
         </div>
-    </div>
+    </fieldset>
 </script>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -18,7 +18,7 @@
                class="title"
                value="{{ zone.title }}"
                required />
-        <a href="#" class="remove-zone hidden">
+        <a class="remove-zone hidden">
             <div class="icon remove"></div>
         </a>
         <label for="zone-{{index}}-description">{{i18n "Description"}}</label>
@@ -104,7 +104,7 @@
                        class="item-text"
                        value="{{ displayName }}" />
             </label>
-            <a href="#" class="remove-item hidden">
+            <a class="remove-item hidden">
                 <div class="icon remove"></div>
             </a>
         </div>
@@ -141,7 +141,7 @@
                       class="error-feedback">{{ feedback.incorrect }}</textarea>
         </div>
         <div class="row advanced-link">
-            <a href="#">{{i18n "Show advanced settings" }}</a>
+            <a>{{i18n "Show advanced settings" }}</a>
         </div>
         <div class="row advanced">
             <label>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -15,16 +15,16 @@
             <div class="icon remove"></div>
         </a>
         <label>
-            <span>{{i18n "Text"}}</span>
+            <span>{{i18n "Title"}}</span>
             <input type="text"
-                   class="title"
+                   class="zone-title"
                    value="{{ zone.title }}"
                    required />
         </label>
         <label>
             <span>{{i18n "Description"}}</span>
             <input type="text"
-                   class="description"
+                   class="zone-description"
                    value="{{ zone.description }}"
                    placeholder="{{i18n 'Describe this zone to non-visual users'}}"
                    required />
@@ -33,33 +33,33 @@
             <label>
                 <span>{{i18n "width"}}</span>
                 <input type="text"
-                       class="size width"
+                       class="zone-size zone-width"
                        value="{{ zone.width }}" />
             </label>
             <label>
                 <span>{{i18n "height"}}</span>
                 <input type="text"
-                       class="size height"
+                       class="zone-size zone-height"
                        value="{{ zone.height }}" />
             </label>
             <br />
             <label>
                 <span>x</span>
                 <input type="text"
-                       class="coord x"
+                       class="zone-coord zone-x"
                        value="{{ zone.x }}" />
             </label>
             <label>
                 <span>y</span>
                 <input type="text"
-                       class="coord y"
+                       class="zone-coord zone-y"
                        value="{{ zone.y }}" />
             </label>
         </div>
         <div class="alignment">
             <label>
                 <span>{{i18n "Alignment"}}</span>
-                <select class="align-select"
+                <select class="zone-align-select"
                         aria-describedby="zone-align-description-{{zone.uid}}-{{id_suffix}}">
                     <option value=""
                         {{#ifeq zone.align ""}}selected{{/ifeq}}>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -12,7 +12,7 @@
 <script class="zone-input-tpl" type="text/html">
     <fieldset class="zone-row" data-uid="{{zone.uid}}">
         <button type="button" class="btn remove-zone hidden" title="{{i18n 'Remove zone'}}">
-            <span class="icon remove"></span>
+            <span class="icon remove" aria-hidden="true"></span>
         </button>
         <label>
             <span>{{i18n "Title"}}</span>
@@ -104,7 +104,7 @@
 <script class="item-input-tpl" type="text/html">
     <fieldset class="item">
         <button type="button" class="btn remove-item hidden" title="{{i18n 'Remove item'}}">
-            <span class="icon remove"></span>
+            <span class="icon remove" aria-hidden="true"></span>
         </button>
         <div class="row">
             <label class="h4">

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -90,6 +90,7 @@ msgid "I don't belong anywhere"
 msgstr ""
 
 #: drag_and_drop_v2.py
+#: templates/html/js_templates.html
 msgid "Title"
 msgstr ""
 
@@ -121,7 +122,6 @@ msgid "Assessment"
 msgstr ""
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Maximum attempts"
 msgstr ""
 
@@ -132,7 +132,6 @@ msgid ""
 msgstr ""
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Show title"
 msgstr ""
 
@@ -141,16 +140,14 @@ msgid "Display the title to the learner?"
 msgstr ""
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Problem text"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "The description of the problem or instructions shown to the learner"
+msgid "The description of the problem or instructions shown to the learner."
 msgstr ""
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Show \"Problem\" heading"
 msgstr ""
 
@@ -159,11 +156,11 @@ msgid "Display the heading \"Problem\" above the problem text?"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "Weight"
+msgid "Maximum score"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "The maximum score the learner can receive for the problem"
+msgid "The maximum score the learner can receive for the problem."
 msgstr ""
 
 #: drag_and_drop_v2.py
@@ -200,7 +197,31 @@ msgid ""
 msgstr ""
 
 #: drag_and_drop_v2.py
+msgid "Number of attempts learner used"
+msgstr ""
+
+#: drag_and_drop_v2.py
 msgid "Indicates whether a learner has completed the problem at least once"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "Keeps maximum achieved score by student"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "do_attempt handler should only be called for assessment mode"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "Max number of attempts reached"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "Unknown DnDv2 mode {mode} - course is misconfigured"
+msgstr ""
+
+#: templates/html/js_templates.html
+msgid "Remove zone"
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -212,7 +233,7 @@ msgid "Description"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "Describe this zone to non-visual users"
+msgid "Describe this zone to non-visual users."
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -250,6 +271,10 @@ msgid ""
 msgstr ""
 
 #: templates/html/js_templates.html
+msgid "Remove item"
+msgstr ""
+
+#: templates/html/js_templates.html
 msgid "Zone"
 msgstr ""
 
@@ -258,7 +283,7 @@ msgid "Image URL (alternative to the text)"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "For example, http://example.com/image.png or /static/image.png"
+msgid "For example, 'http://example.com/image.png' or '/static/image.png'."
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -280,13 +305,17 @@ msgid "Show advanced settings"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid ""
-"Preferred width as a percentage of the background image width (or blank for "
-"automatic width):"
+msgid "Preferred width"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid "Use text that is clear and descriptive of the item to be placed"
+msgid ""
+"Specify preferred width as percentage of the background image width. "
+"Leave blank for automatic width."
+msgstr ""
+
+#: templates/html/js_templates.html
+msgid "Use text that is clear and descriptive of the item to be placed."
 msgstr ""
 
 #: templates/html/drag_and_drop.html
@@ -300,18 +329,6 @@ msgid ""
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Problem title"
-msgstr ""
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Problem mode"
-msgstr ""
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Maximum score"
-msgstr ""
-
-#: templates/html/drag_and_drop_edit.html
 msgid "Introductory Feedback"
 msgstr ""
 
@@ -319,8 +336,8 @@ msgstr ""
 msgid "Final Feedback"
 msgstr ""
 
-#: templates/html/js_templates.html
 #: templates/html/drag_and_drop_edit.html
+#: templates/html/js_templates.html
 msgid "Zones"
 msgstr ""
 
@@ -330,7 +347,7 @@ msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
 msgid ""
-"For example, http://example.com/background.png or /static/background.png"
+"For example, 'http://example.com/background.png' or '/static/background.png'."
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
@@ -351,6 +368,10 @@ msgid ""
 "                            to solve the problem even without seeing the "
 "image.\n"
 "                        "
+msgstr ""
+
+#: templates/html/drag_and_drop_edit.html
+msgid "Zone definitions"
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
@@ -375,14 +396,6 @@ msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Items"
-msgstr ""
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Background color"
-msgstr ""
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Text color"
 msgstr ""
 
 #: templates/html/drag_and_drop_edit.html
@@ -421,6 +434,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
+#: public/js/drag_and_drop.js
 msgid "Submit"
 msgstr ""
 
@@ -468,6 +482,10 @@ msgstr ""
 
 #: public/js/drag_and_drop.js
 msgid "An error occurred. Unable to load drag and drop problem."
+msgstr ""
+
+#: public/js/drag_and_drop.js
+msgid "You have used {used} of {total} attempts."
 msgstr ""
 
 #: public/js/drag_and_drop_edit.js

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -171,7 +171,7 @@ msgid "Item background color"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "The background color of draggable items in the problem."
+msgid "The background color of draggable items in the problem (example: 'blue' or '#0000ff')."
 msgstr ""
 
 #: drag_and_drop_v2.py
@@ -179,7 +179,7 @@ msgid "Item text color"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "Text color to use for draggable items."
+msgid "Text color to use for draggable items (example: 'white' or '#ffffff')."
 msgstr ""
 
 #: drag_and_drop_v2.py

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -113,6 +113,7 @@ msgid "Goes anywhere"
 msgstr "Göés änýwhéré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: drag_and_drop_v2.py
+#: templates/html/js_templates.html
 msgid "Title"
 msgstr "Tïtlé Ⱡ'σяєм ιρѕ#"
 
@@ -151,7 +152,6 @@ msgid "Assessment"
 msgstr "Àsséssmént Ⱡ'σяєм ιρѕυм ∂σłσ#"
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Maximum attempts"
 msgstr "Mäxïmüm ättémpts Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
 
@@ -164,7 +164,6 @@ msgstr ""
 "Ìf thé välüé ïs nöt sét, ïnfïnïté ättémpts äré ällöwéd. Ⱡ'σяєм #"
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Show title"
 msgstr "Shöw tïtlé Ⱡ'σяєм ιρѕυм ∂σłσ#"
 
@@ -174,14 +173,13 @@ msgstr ""
 "Dïspläý thé tïtlé tö thé léärnér? Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тє#"
 
 #: drag_and_drop_v2.py
-#: templates/html/drag_and_drop_edit.html
 msgid "Problem text"
 msgstr "Prößlém téxt Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: drag_and_drop_v2.py
-msgid "The description of the problem or instructions shown to the learner"
+msgid "The description of the problem or instructions shown to the learner."
 msgstr ""
-"Thé désçrïptïön öf thé prößlém ör ïnstrüçtïöns shöwn tö thé léärnér Ⱡ'σяєм "
+"Thé désçrïptïön öf thé prößlém ör ïnstrüçtïöns shöwn tö thé léärnér. Ⱡ'σяєм "
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: drag_and_drop_v2.py
@@ -195,11 +193,11 @@ msgstr ""
 "ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: drag_and_drop_v2.py
-msgid "Weight"
-msgstr "Wéïght Ⱡ'σяєм ιρѕυ#"
+msgid "Maximum score"
+msgstr Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#
 
 #: drag_and_drop_v2.py
-msgid "The maximum score the learner can receive for the problem"
+msgid "The maximum score the learner can receive for the problem."
 msgstr ""
 "Thé mäxïmüm sçöré thé léärnér çän réçéïvé för thé prößlém Ⱡ'σяєм ιρѕυм ∂σłσя"
 " ѕιт αмєт, ¢σηѕє¢тєтυя α#"
@@ -252,10 +250,34 @@ msgstr ""
 "thé tärgét ïmägé. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢ση#"
 
 #: drag_and_drop_v2.py
+msgid "Number of attempts learner used"
+msgstr "Nümßér öf ättémpts léärnér üséd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+
+#: drag_and_drop_v2.py
 msgid "Indicates whether a learner has completed the problem at least once"
 msgstr ""
 "Ìndïçätés whéthér ä léärnér häs çömplétéd thé prößlém ät léäst önçé Ⱡ'σяєм "
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
+
+#: drag_and_drop_v2.py
+msgid "Keeps maximum achieved score by student"
+msgstr "Kééps mäxïmüm äçhïévéd sçöré ßý stüdént Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
+
+#: drag_and_drop_v2.py
+msgid "do_attempt handler should only be called for assessment mode"
+msgstr "dö_ättémpt händlér shöüld önlý ßé çälléd för ässéssmént mödé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: drag_and_drop_v2.py
+msgid "Max number of attempts reached"
+msgstr "Mäx nümßér öf ättémpts réäçhéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+
+#: drag_and_drop_v2.py
+msgid "Unknown DnDv2 mode {mode} - course is misconfigured"
+msgstr "Ûnknöwn DnDv2 mödé {mode} - çöürsé ïs mïsçönfïgüréd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: templates/html/js_templates.html
+msgid "Remove zone"
+msgstr "Rémövé zöné Ⱡ'σяєм ιρѕυм ∂σłσя #"
 
 #: templates/html/js_templates.html
 msgid "Text"
@@ -266,9 +288,9 @@ msgid "Description"
 msgstr "Désçrïptïön Ⱡ'σяєм ιρѕυм ∂σłσя #"
 
 #: templates/html/js_templates.html
-msgid "Describe this zone to non-visual users"
+msgid "Describe this zone to non-visual users."
 msgstr ""
-"Désçrïßé thïs zöné tö nön-vïsüäl üsérs Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
+"Désçrïßé thïs zöné tö nön-vïsüäl üsérs. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
 "¢σηѕє¢тєтυя#"
 
 #: templates/html/js_templates.html
@@ -308,6 +330,10 @@ msgstr ""
 "(ïtéms stäý éxäçtlý whéré thé üsér dröps thém). Ⱡ'σяєм ιρ#"
 
 #: templates/html/js_templates.html
+msgid "Remove item"
+msgstr "Rémövé ïtém Ⱡ'σяєм ιρѕυм ∂σłσя #"
+
+#: templates/html/js_templates.html
 msgid "Zone"
 msgstr "Zöné Ⱡ'σяєм ι#"
 
@@ -317,7 +343,7 @@ msgstr ""
 "Ìmägé ÛRL (ältérnätïvé tö thé téxt) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
 
 #: templates/html/js_templates.html
-msgid "For example, http://example.com/image.png or /static/image.png"
+msgid "For example, 'http://example.com/image.png' or '/static/image.png'."
 msgstr ""
 "För éxämplé, http://éxämplé.çöm/ïmägé.png ör /stätïç/ïmägé.png Ⱡ'σяєм ιρѕυм "
 "∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
@@ -343,12 +369,16 @@ msgid "Show advanced settings"
 msgstr "Shöw ädvänçéd séttïngs Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
 
 #: templates/html/js_templates.html
+msgid "Preferred width"
+msgstr "Préférréd wïdth Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт α#"
+
+#: templates/html/js_templates.html
 msgid ""
-"Preferred width as a percentage of the background image width (or blank for "
-"automatic width):"
+"Specify preferred width as percentage of the background image width. "
+"Leave blank for automatic width."
 msgstr ""
-"Préférréd wïdth äs ä pérçéntägé öf thé ßäçkgröünd ïmägé wïdth (ör ßlänk för "
-"äütömätïç wïdth): Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σ#"
+"Spéçïfý préférréd wïdth äs pérçéntägé öf thé ßäçkgröünd ïmägé wïdth. "
+"Léävé ßlänk för äütömätïç wïdth. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмє#"
 
 #: templates/html/js_templates.html
 #: templates/html/drag_and_drop_edit.html
@@ -356,9 +386,9 @@ msgid "Zones"
 msgstr "Zönés Ⱡ'σяєм ιρѕ#"
 
 #: templates/html/js_templates.html
-msgid "Use text that is clear and descriptive of the item to be placed"
+msgid "Use text that is clear and descriptive of the item to be placed."
 msgstr ""
-"Ûsé téxt thät ïs çléär änd désçrïptïvé öf thé ïtém tö ßé pläçéd Ⱡ'σяєм "
+"Ûsé téxt thät ïs çléär änd désçrïptïvé öf thé ïtém tö ßé pläçéd. Ⱡ'σяєм "
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: templates/html/drag_and_drop.html
@@ -374,18 +404,6 @@ msgstr ""
 "thé prößlém änd çréäté ä néw öné. Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
 
 #: templates/html/drag_and_drop_edit.html
-msgid "Problem title"
-msgstr "Prößlém tïtlé Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Problem mode"
-msgstr "Prößlém mödé Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Maximum score"
-msgstr "Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
-
-#: templates/html/drag_and_drop_edit.html
 msgid "Introductory Feedback"
 msgstr "Ìntrödüçtörý Féédßäçk Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
@@ -399,9 +417,9 @@ msgstr "Bäçkgröünd ÛRL Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid ""
-"For example, http://example.com/background.png or /static/background.png"
+"For example, 'http://example.com/background.png' or '/static/background.png'."
 msgstr ""
-"För éxämplé, http://éxämplé.çöm/ßäçkgröünd.png ör /stätïç/ßäçkgröünd.png "
+"För éxämplé, 'http://éxämplé.çöm/ßäçkgröünd.png' ör '/stätïç/ßäçkgröünd.png'. "
 "Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
 
 #: templates/html/drag_and_drop_edit.html
@@ -425,6 +443,10 @@ msgstr ""
 "                            Thé désçrïptïön shöüld prövïdé süffïçïént ïnförmätïön tö ällöw änýöné\n"
 "                            tö sölvé thé prößlém évén wïthöüt sééïng thé ïmägé.\n"
 "                         Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α∂ιριѕι¢ιηg єłιт, ѕє∂ ∂σ єιυѕмσ∂ тємρσя ιη¢ι∂ι∂υηт υт łαвσяє єт ∂σłσяє мαgηα αłιqυα. υт єηιм α∂ мιηιм νєηιαм, qυιѕ ησѕтяυ∂ єχєя¢ιтαтιση υłłαм¢#"
+
+#: templates/html/drag_and_drop_edit.html
+msgid "Zone definitions"
+msgstr "Zöné défïnïtïöns Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Zone labels"
@@ -451,14 +473,6 @@ msgstr "Àdd ä zöné Ⱡ'σяєм ιρѕυм ∂σłσ#"
 #: templates/html/drag_and_drop_edit.html
 msgid "Items"
 msgstr "Ìtéms Ⱡ'σяєм ιρѕ#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Background color"
-msgstr "Bäçkgröünd çölör Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αм#"
-
-#: templates/html/drag_and_drop_edit.html
-msgid "Text color"
-msgstr "Téxt çölör Ⱡ'σяєм ιρѕυм ∂σłσ#"
 
 #: templates/html/drag_and_drop_edit.html
 msgid "Add an item"
@@ -496,6 +510,7 @@ msgstr "Çörréçtlý pläçéd ïn: {zone_title} Ⱡ'σяєм ιρѕυм ∂σ
 msgid "Reset"
 msgstr "Rését Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
+#: public/js/drag_and_drop.js
 msgid "Submit"
 msgstr "Süßmït Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
@@ -556,6 +571,10 @@ msgid "An error occurred. Unable to load drag and drop problem."
 msgstr ""
 "Àn érrör öççürréd. Ûnäßlé tö löäd dräg änd dröp prößlém. Ⱡ'σяєм ιρѕυм ∂σłσя "
 "ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: public/js/drag_and_drop.js
+msgid "You have used {used} of {total} attempts."
+msgstr "Ýöü hävé üséd {used} öf {total} ättémpts. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
 
 #: public/js/drag_and_drop_edit.js
 msgid "There was an error with your form."

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -209,20 +209,20 @@ msgid "Item background color"
 msgstr "Ìtém ßäçkgröünd çölör Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: drag_and_drop_v2.py
-msgid "The background color of draggable items in the problem."
+msgid "The background color of draggable items in the problem (example: 'blue' or '#0000ff')."
 msgstr ""
-"Thé ßäçkgröünd çölör öf dräggäßlé ïtéms ïn thé prößlém. Ⱡ'σяєм ιρѕυм ∂σłσя "
-"ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+"Thé ßäçkgröünd çölör öf dräggäßlé ïtéms ïn thé prößlém (éxämplé: 'ßlüé' ör '#0000ff'). "
+"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
 
 #: drag_and_drop_v2.py
 msgid "Item text color"
 msgstr "Ìtém téxt çölör Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт α#"
 
 #: drag_and_drop_v2.py
-msgid "Text color to use for draggable items."
+msgid "Text color to use for draggable items (example: 'white' or '#ffffff')."
 msgstr ""
-"Téxt çölör tö üsé för dräggäßlé ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, "
-"¢σηѕє¢тєтυя#"
+"Téxt çölör tö üsé för dräggäßlé ïtéms (éxämplé: 'whïté' ör '#ffffff'). "
+"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: drag_and_drop_v2.py
 msgid "Problem data"


### PR DESCRIPTION
**Description**:

This PR cleans up the Studio edit template and associated JS code to:

- Use `field.display_name` values for field labels instead of hardcoding/duplicating the names in the template.
- Directly display help text under associated input field instead of `title` and `<span class="sr">`.
- Replace usage of HTML `id` attributes with `class`-es. In cases where that is not possible, ensure that the `id` attributes are globally unique.
- Use `<button>` elements instead of `<a>` elements for buttons.
- Replace input placeholders with help texts visible to everyone.

**Screenshots**:

Before:

<img width="960" alt="screen shot 2016-08-04 at 17 53 48" src="https://cloud.githubusercontent.com/assets/32585/17397985/1c4c2a36-5a6d-11e6-9521-86a0551a1fc3.png">

After:

<img width="965" alt="screen shot 2016-08-04 at 17 52 52" src="https://cloud.githubusercontent.com/assets/32585/17397996/246f5558-5a6d-11e6-94c4-94e4c2bac7ca.png">

**JIRA ticket**: https://openedx.atlassian.net/browse/SOL-1990

**Dependencies**: None

**Discussions**: https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/77#discussion_r71034788

**Sandbox URLs** (installed version 9845083078d129009933cd8c8106b27c14e17242):

- LMS: http://dndv2-sandbox5.opencraft.hosting/
- Studio: http://studio-dndv2-sandbox5.opencraft.hosting/

You are probably mostly interested in the Studio edit functionality. Some DnDv2 blocks can be edited at: http://studio-dndv2-sandbox5.opencraft.hosting/container/block-v1:OpenCraftX+OC1+1+type@vertical+block@e3c62b19090948b8ad89d3386bff4435

**Testing Instructions**:

This PR does not implement any new functionality, so there is no specific feature to test.
The important thing is to ensure that the studio edit functionality continues to look and function correctly.

**Reviewers**:

- [x] OpenCraft: @bradenmacdonald
- [x] TNL: @cahrens and/or @staubina
- [ ] ~~a11y: @edx/edx-accessibility~~ Scheduled combined review for all DnDv2.1 stories: [SOL-1978](https://openedx.atlassian.net/browse/SOL-1978)
- [x] Product: @sstack22 