### PR TITLE
Prevent overlapping drop placements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The editor is fully guided. Features include:
 * custom zone labels
 * ability to show or hide zone borders
 * custom text and background colors for items
-* optional auto-alignment for items (left, right, center)
+* auto-alignment for items: left, right, center
 * image items
 * decoy items that don't have a zone
 * feedback popups for both correct and incorrect attempts
@@ -122,15 +122,13 @@ whether or not to display borders outlining the zones. It is possible
 to define an arbitrary number of drop zones as long as their labels
 are unique.
 
-Additionally, you can specify the alignment for items once they are dropped in
-the zone.  No alignment is the default, and causes items to stay where the
-learner drops them.  Left alignment causes dropped items to be placed from left
+You can specify the alignment for items once they are dropped in
+the zone. Centered alignment is the default, and places items from top to bottom
+along the center of the zone. Left alignment causes dropped items to be placed from left
 to right across the zone. Right alignment causes the items to be placed from
-right to left across the zone. Center alignment places items from top to bottom
-along the center of the zone. If left, right, or center alignment is chosen,
-items dropped in a zone will not overlap, but if the zone is not made large
-enough for all its items, they will overflow the bottom of the zone, and
-potentially, overlap the zones below.
+right to left across the zone. Items dropped in a zone will not overlap,
+but if the zone is not made large enough for all its items, they will overflow the bottom
+of the zone, and potentially overlap the zones below.
 
 ![Drag item edit](/doc/img/edit-view-items.png)
 
@@ -150,6 +148,9 @@ You can leave all of the checkboxes unchecked in order to create a
 
 You can define an arbitrary number of drag items, each of which may
 be attached to any number of zones.
+
+"Maximum items per Zone" setting controls how many items can be dropped into a
+single zone, allowing some degree of control over items overlapping zones below.
 
 Scoring
 -------

--- a/drag_and_drop_v2/default_data.py
+++ b/drag_and_drop_v2/default_data.py
@@ -38,6 +38,7 @@ DEFAULT_DATA = {
             "y": 30,
             "width": 196,
             "height": 178,
+            "align": "center"
         },
         {
             "uid": MIDDLE_ZONE_ID,
@@ -47,6 +48,7 @@ DEFAULT_DATA = {
             "y": 210,
             "width": 340,
             "height": 138,
+            "align": "center"
         },
         {
             "uid": BOTTOM_ZONE_ID,
@@ -56,6 +58,7 @@ DEFAULT_DATA = {
             "y": 350,
             "width": 485,
             "height": 135,
+            "align": "center"
         }
     ],
     "items": [
@@ -65,7 +68,9 @@ DEFAULT_DATA = {
                 "incorrect": ITEM_INCORRECT_FEEDBACK,
                 "correct": ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE)
             },
-            "zones": [TOP_ZONE_ID],
+            "zones": [
+                TOP_ZONE_ID
+            ],
             "imageURL": "",
             "id": 0,
         },
@@ -75,7 +80,9 @@ DEFAULT_DATA = {
                 "incorrect": ITEM_INCORRECT_FEEDBACK,
                 "correct": ITEM_CORRECT_FEEDBACK.format(zone=MIDDLE_ZONE_TITLE)
             },
-            "zones": [MIDDLE_ZONE_ID],
+            "zones": [
+                MIDDLE_ZONE_ID
+            ],
             "imageURL": "",
             "id": 1,
         },
@@ -85,7 +92,9 @@ DEFAULT_DATA = {
                 "incorrect": ITEM_INCORRECT_FEEDBACK,
                 "correct": ITEM_CORRECT_FEEDBACK.format(zone=BOTTOM_ZONE_TITLE)
             },
-            "zones": [BOTTOM_ZONE_ID],
+            "zones": [
+                BOTTOM_ZONE_ID
+            ],
             "imageURL": "",
             "id": 2,
         },
@@ -95,7 +104,11 @@ DEFAULT_DATA = {
                 "incorrect": "",
                 "correct": ITEM_ANY_ZONE_FEEDBACK
             },
-            "zones": [TOP_ZONE_ID, BOTTOM_ZONE_ID, MIDDLE_ZONE_ID],
+            "zones": [
+                TOP_ZONE_ID,
+                BOTTOM_ZONE_ID,
+                MIDDLE_ZONE_ID
+            ],
             "imageURL": "",
             "id": 3
         },

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -171,9 +171,9 @@
     text-align: center;
 }
 .xblock--drag-and-drop .zone .item-align-center .option {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
+    display: inline-block;
+    margin-left: 1px;
+    margin-right: 1px;
 }
 
 /* Focused option */

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -166,14 +166,10 @@ function DragAndDropEditBlock(runtime, element, params) {
                             $(this).addClass('hidden');
                             $('.save-button', element).parent()
                                 .removeClass('hidden')
-                                .one('click', function submitForm(e) {
+                                .on('click', function submitForm(e) {
                                     // $itemTab -> submit
 
                                     e.preventDefault();
-                                    if (!self.validate()) {
-                                        $(e.target).one('click', submitForm);
-                                        return
-                                    }
                                     _fn.build.form.submit();
                                 });
                         });
@@ -190,7 +186,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                         })
                         .on('click', '.remove-zone', _fn.build.form.zone.remove)
                         .on('input', '.zone-row input', _fn.build.form.zone.changedInputHandler)
-                        .on('change', '.align-select', _fn.build.form.zone.changedInputHandler)
+                        .on('change', '.zone-align-select', _fn.build.form.zone.changedInputHandler)
                         .on('click', '.target-image-form button', function(e) {
                             var new_img_url = $.trim($('.target-image-form .background-url', element).val());
                             if (new_img_url) {
@@ -516,19 +512,21 @@ function DragAndDropEditBlock(runtime, element, params) {
                             'show_problem_header': $element.find('.show-problem-header').is(':checked'),
                             'item_background_color': $element.find('.item-background-color').val(),
                             'item_text_color': $element.find('.item-text-color').val(),
+                            'max_items_per_zone': $element.find('.max-items-per-zone').val(),
                             'data': _fn.data,
                         };
 
-                        $('.xblock-editor-error-message', element).html();
-                        $('.xblock-editor-error-message', element).css('display', 'none');
                         var handlerUrl = runtime.handlerUrl(element, 'studio_submit');
+                        runtime.notify('save', {state: 'start', message: gettext("Saving")});
                         $.post(handlerUrl, JSON.stringify(data), 'json').done(function(response) {
                             if (response.result === 'success') {
-                                window.location.reload(false);
+                                runtime.notify('save', {state: 'end'});
                             } else {
-                                $('.xblock-editor-error-message', element)
-                                    .html(gettext('Error: ') + response.message);
-                                $('.xblock-editor-error-message', element).css('display', 'block');
+                                var message = response.messages.join(", ");
+                                runtime.notify('error', {
+                                    'title': window.gettext("There was an error with your form."),
+                                    'message': message
+                                });
                             }
                         });
                     }

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -174,6 +174,15 @@
                     <div id="item-text-color-description-{{id_suffix}}" class="form-help">
                       {% trans fields.item_text_color.help %}
                     </div>
+                    <label class="h4">
+                        <span>{% trans fields.max_items_per_zone.display_name %}</span>
+                        <input type="number" min="1" step="1" class="max-items-per-zone"
+                               value="{{ self.max_items_per_zone|unlocalize }}"
+                               aria-describedby="max-items-per-zone-description-{{id_suffix}}">
+                    </label>
+                    <div id="max-items-per-zone-description-{{id_suffix}}" class="form-help">
+                      {% trans fields.max_items_per_zone.help %}
+                    </div>
                 </form>
             </section>
             <section class="tab-content">
@@ -189,8 +198,7 @@
     </section>
 
     <div class="xblock-actions">
-      <span class="xblock-editor-error-message"></span>
-      <ul>
+      <ul class="action-buttons">
         <li class="action-item">
           <a href="#" class="button action-primary continue-button">{% trans "Continue" %}</a>
         </li>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -64,10 +64,6 @@
                 <span>{{i18n "Alignment"}}</span>
                 <select class="zone-align-select"
                         aria-describedby="zone-align-description-{{zone.uid}}-{{id_suffix}}">
-                    <option value=""
-                        {{#ifeq zone.align ""}}selected{{/ifeq}}>
-                        {{i18n "none"}}
-                    </option>
                     <option value="left"
                         {{#ifeq zone.align "left"}}selected{{/ifeq}}>
                         {{i18n "left"}}
@@ -83,7 +79,7 @@
                 </select>
             </label>
             <div id="zone-align-description-{{zone.uid}}-{{id_suffix}}" class="form-help">
-                {{i18n "Align dropped items to the left, center, or right.  Default is no alignment (items stay exactly where the user drops them)."}}
+                {{i18n "Align dropped items to the left, center, or right."}}
             </div>
         </div>
     </fieldset>

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -90,6 +90,10 @@ msgid "I don't belong anywhere"
 msgstr ""
 
 #: drag_and_drop_v2.py
+#: msgid "This setting limits the number of items that can be dropped into a single zone."
+#: msgstr ""
+
+#: drag_and_drop_v2.py
 #: templates/html/js_templates.html
 msgid "Title"
 msgstr ""
@@ -205,10 +209,6 @@ msgid "Indicates whether a learner has completed the problem at least once"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "Keeps maximum achieved score by student"
-msgstr ""
-
-#: drag_and_drop_v2.py
 msgid "do_attempt handler should only be called for assessment mode"
 msgstr ""
 
@@ -222,6 +222,19 @@ msgstr ""
 
 #: templates/html/js_templates.html
 msgid "Remove zone"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "Keeps maximum score achieved by student"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "Failed to parse \"Maximum items per zone\""
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid ""
+"\"Maximum items per zone\" should be positive integer, got {max_items_per_zone}"
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -265,9 +278,7 @@ msgid "right"
 msgstr ""
 
 #: templates/html/js_templates.html
-msgid ""
-"Align dropped items to the left, center, or right.  Default is no alignment "
-"(items stay exactly where the user drops them)."
+msgid "Align dropped items to the left, center, or right."
 msgstr ""
 
 #: templates/html/js_templates.html
@@ -498,10 +509,6 @@ msgstr ""
 
 #: public/js/drag_and_drop_edit.js
 msgid "None"
-msgstr ""
-
-#: public/js/drag_and_drop_edit.js
-msgid "Error: "
 msgstr ""
 
 #: utils.py:18

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -118,6 +118,10 @@ msgid "Title"
 msgstr "Tïtlé Ⱡ'σяєм ιρѕ#"
 
 #: drag_and_drop_v2.py
+#: msgid "This setting limits the number of items that can be dropped into a single zone."
+#: msgstr "Thïs séttïng lïmïts thé nümßér öf ïtéms thät çän ßé dröppéd ïntö ä sïnglé zöné."
+
+#: drag_and_drop_v2.py
 msgid ""
 "The title of the drag and drop problem. The title is displayed to learners."
 msgstr ""
@@ -194,7 +198,7 @@ msgstr ""
 
 #: drag_and_drop_v2.py
 msgid "Maximum score"
-msgstr Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#
+msgstr "Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: drag_and_drop_v2.py
 msgid "The maximum score the learner can receive for the problem."
@@ -260,10 +264,6 @@ msgstr ""
 "ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: drag_and_drop_v2.py
-msgid "Keeps maximum achieved score by student"
-msgstr "Kééps mäxïmüm äçhïévéd sçöré ßý stüdént Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
-
-#: drag_and_drop_v2.py
 msgid "do_attempt handler should only be called for assessment mode"
 msgstr "dö_ättémpt händlér shöüld önlý ßé çälléd för ässéssmént mödé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
@@ -278,6 +278,19 @@ msgstr "Ûnknöwn DnDv2 mödé {mode} - çöürsé ïs mïsçönfïgüréd Ⱡ'�
 #: templates/html/js_templates.html
 msgid "Remove zone"
 msgstr "Rémövé zöné Ⱡ'σяєм ιρѕυм ∂σłσя #"
+
+#: drag_and_drop_v2.py
+msgid "Keeps maximum score achieved by student"
+msgstr "Kééps mäxïmüm sçöré äçhïévéd ßý stüdént Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя#"
+
+#: drag_and_drop_v2.py
+msgid "Failed to parse \"Maximum items per zone\""
+msgstr "Fäïléd tö pärsé \"Mäxïmüm ïtéms pér zöné\" Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυ#"
+
+#: drag_and_drop_v2.py
+msgid ""
+"\"Maximum items per zone\" should be positive integer, got {max_items_per_zone}"
+msgstr "\"Mäxïmüm ïtéms pér zöné\" shöüld ßé pösïtïvé ïntégér, göt {max_items_per_zone} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: templates/html/js_templates.html
 msgid "Text"
@@ -322,12 +335,8 @@ msgid "right"
 msgstr "rïght Ⱡ'σяєм ιρѕ#"
 
 #: templates/html/js_templates.html
-msgid ""
-"Align dropped items to the left, center, or right.  Default is no alignment "
-"(items stay exactly where the user drops them)."
-msgstr ""
-"Àlïgn dröppéd ïtéms tö thé léft, çéntér, ör rïght.  Défäült ïs nö älïgnmént "
-"(ïtéms stäý éxäçtlý whéré thé üsér dröps thém). Ⱡ'σяєм ιρ#"
+msgid "Align dropped items to the left, center, or right."
+msgstr "Àlïgn dröppéd ïtéms tö thé léft, çéntér, ör rïght. Ⱡ'σяєм ιρ#"
 
 #: templates/html/js_templates.html
 msgid "Remove item"
@@ -589,11 +598,6 @@ msgstr ""
 #: public/js/drag_and_drop_edit.js
 msgid "None"
 msgstr "Nöné Ⱡ'σяєм ι#"
-
-#: public/js/drag_and_drop_edit.js
-msgid "Error: "
-msgstr "Érrör:  Ⱡ'σяєм ιρѕυм #"
-
 
 #: utils.py:18
 msgid "Fïnäl ättémpt wäs üséd, hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"

--- a/drag_and_drop_v2/utils.py
+++ b/drag_and_drop_v2/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Drag and Drop v2 XBlock - Utils """
+import copy
 from collections import namedtuple
 
 
@@ -82,3 +83,200 @@ ItemStats = namedtuple(  # pylint: disable=invalid-name
     'ItemStats',
     ["required", "placed", "correctly_placed", "decoy", "decoy_in_bank"]
 )
+
+
+class Constants(object):
+    """
+    Namespace class for various constants
+    """
+    ALLOWED_ZONE_ALIGNMENTS = ['left', 'right', 'center']
+    DEFAULT_ZONE_ALIGNMENT = 'center'
+
+    STANDARD_MODE = "standard"
+    ASSESSMENT_MODE = "assessment"
+
+
+class StateMigration(object):
+    """
+    Helper class to apply zone data and item state migrations
+    """
+    def __init__(self, block):
+        self._block = block
+
+    @staticmethod
+    def _apply_migration(obj_id, obj, migrations):
+        """
+        Applies migrations sequentially to a copy of an `obj`, to avoid updating actual data
+        """
+        tmp = copy.deepcopy(obj)
+        for method in migrations:
+            tmp = method(obj_id, tmp)
+
+        return tmp
+
+    def apply_zone_migrations(self, zone):
+        """
+        Applies zone migrations
+        """
+        migrations = (self._zone_v1_to_v2, self._zone_v2_to_v2p1)
+        zone_id = zone.get('uid', zone.get('id'))
+
+        return self._apply_migration(zone_id, zone, migrations)
+
+    def apply_item_state_migrations(self, item_id, item_state):
+        """
+        Applies item_state migrations
+        """
+        migrations = (self._item_state_v1_to_v1p5, self._item_state_v1p5_to_v2, self._item_state_v2_to_v2p1)
+
+        return self._apply_migration(item_id, item_state, migrations)
+
+    @classmethod
+    def _zone_v1_to_v2(cls, unused_zone_id, zone):
+        """
+        Migrates zone data from v1.0 format to v2.0 format.
+
+        Changes:
+        * v1 used zone "title" as UID, while v2 zone has dedicated "uid" property
+        * "id" and "index" properties are no longer used
+
+        In: {'id': 1, 'index': 2, 'title': "Zone", ...}
+        Out: {'uid': "Zone", ...}
+        """
+        if "uid" not in zone:
+            zone["uid"] = zone.get("title")
+        zone.pop("id", None)
+        zone.pop("index", None)
+
+        return zone
+
+    @classmethod
+    def _zone_v2_to_v2p1(cls, unused_zone_id, zone):
+        """
+        Migrates zone data from v2.0 to v2.1
+
+        Changes:
+        * Removed "none" zone alignment; default align is "center"
+
+        In: {
+            'uid': "Zone", "align": "none",
+            "x_percent": "10%", "y_percent": "10%", "width_percent": "10%", "height_percent": "10%"
+        }
+        Out: {
+            'uid': "Zone", "align": "center",
+            "x_percent": "10%", "y_percent": "10%", "width_percent": "10%", "height_percent": "10%"
+        }
+        """
+        if zone.get('align', None) not in Constants.ALLOWED_ZONE_ALIGNMENTS:
+            zone['align'] = Constants.DEFAULT_ZONE_ALIGNMENT
+
+        return zone
+
+    @classmethod
+    def _item_state_v1_to_v1p5(cls, unused_item_id, item):
+        """
+        Migrates item_state from v1.0 to v1.5
+
+        Changes:
+        * Item state is now a dict instead of tuple
+
+        In: ('100px', '120px')
+        Out: {'top': '100px', 'left': '120px'}
+        """
+        if isinstance(item, dict):
+            return item
+        else:
+            return {'top': item[0], 'left': item[1]}
+
+    @classmethod
+    def _item_state_v1p5_to_v2(cls, unused_item_id, item):
+        """
+        Migrates item_state from v1.5 to v2.0
+
+        Changes:
+        * Item placement attributes switched from absolute (left-top) to relative (x_percent-y_percent) units
+
+        In: {'zone': 'Zone", 'correct': True, 'top': '100px', 'left': '120px'}
+        Out: {'zone': 'Zone", 'correct': True, 'top': '100px', 'left': '120px'}
+        """
+        # Conversion can't be made as parent dimensions are unknown to python - converted in JS
+        # Since 2.1 JS this conversion became unnecesary, so it was removed from JS code
+        return item
+
+    def _item_state_v2_to_v2p1(self, item_id, item):
+        """
+        Migrates item_state from v2.0 to v2.1
+
+        * Single item can correspond to multiple zones - "zone" key is added to each item
+        * Assessment mode - "correct" key is added to each item
+        * Removed "no zone align" option; only automatic alignment is now allowed - removes attributes related to
+          "absolute" placement of an item (relative to background image, as opposed to the zone)
+        """
+        self._multiple_zones_migration(item_id, item)
+        self._assessment_mode_migration(item)
+        self._automatic_alignment_migration(item)
+
+        return item
+
+    def _multiple_zones_migration(self, item_id, item):
+        """
+        Changes:
+        * Adds "zone" attribute
+
+        In: {'item_id': 0}
+        Out: {'zone': 'Zone", 'item_id": 0}
+
+        In: {'item_id': 1}
+        Out: {'zone': 'unknown", 'item_id": 1}
+        """
+        if item.get('zone') is None:
+            valid_zones = self._block.get_item_zones(int(item_id))
+            if valid_zones:
+                # If we get to this point, then the item was placed prior to support for
+                # multiple correct zones being added. As a result, it can only be correct
+                # on a single zone, and so we can trust that the item was placed on the
+                # zone with index 0.
+                item['zone'] = valid_zones[0]
+            else:
+                item['zone'] = 'unknown'
+
+    @classmethod
+    def _assessment_mode_migration(cls, item):
+        """
+        Changes:
+        * Adds "correct" attribute if missing
+
+        In: {'item_id': 0}
+        Out: {'item_id': 'correct': True}
+
+        In: {'item_id': 0, 'correct': True}
+        Out: {'item_id': 'correct': True}
+
+        In: {'item_id': 0, 'correct': False}
+        Out: {'item_id': 'correct': False}
+        """
+        # If correctness information is missing
+        # (because problem was completed before assessment mode was implemented),
+        # assume the item is in correct zone (in standard mode, only items placed
+        # into correct zone are stored in item state).
+        if item.get('correct') is None:
+            item['correct'] = True
+
+    @classmethod
+    def _automatic_alignment_migration(cls, item):
+        """
+        Changes:
+        * Removed old "absolute" placement attributes
+        * Removed "none" zone alignment, making "x_percent" and "y_percent" attributes obsolete
+
+        In: {'zone': 'Zone", 'correct': True, 'top': '100px', 'left': '120px', 'absolute': true}
+        Out: {'zone': 'Zone", 'correct': True}
+
+        In: {'zone': 'Zone", 'correct': True, 'x_percent': '90%', 'y_percent': '20%'}
+        Out: {'zone': 'Zone", 'correct': True}
+        """
+        attributes_to_remove = ['x_percent', 'y_percent', 'left', 'top', 'absolute']
+        for attribute in attributes_to_remove:
+            item.pop(attribute, None)
+
+        return item

--- a/pylintrc
+++ b/pylintrc
@@ -17,7 +17,7 @@ disable=
 min-similarity-lines=4
 
 [OPTIONS]
-good-names=_,__,log,loader
+good-names=_,__,logger,loader
 method-rgx=_?[a-z_][a-z0-9_]{2,40}$
 function-rgx=_?[a-z_][a-z0-9_]{2,40}$
 method-name-hint=_?[a-z_][a-z0-9_]{2,40}$

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -1,6 +1,11 @@
+# -*- coding: utf-8 -*-
+#
 # Imports ###########################################################
 
+import json
 from xml.sax.saxutils import escape
+from selenium.webdriver import ActionChains
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
 from bok_choy.promise import EmptyPromise
@@ -9,6 +14,13 @@ from xblockutils.resources import ResourceLoader
 
 from xblockutils.base_test import SeleniumBaseTest
 
+from drag_and_drop_v2.utils import Constants
+
+from drag_and_drop_v2.default_data import (
+    DEFAULT_DATA, START_FEEDBACK, FINISH_FEEDBACK,
+    TOP_ZONE_ID, TOP_ZONE_TITLE, MIDDLE_ZONE_ID, MIDDLE_ZONE_TITLE, BOTTOM_ZONE_ID, BOTTOM_ZONE_TITLE,
+    ITEM_CORRECT_FEEDBACK, ITEM_INCORRECT_FEEDBACK, ITEM_ANY_ZONE_FEEDBACK, ITEM_NO_ZONE_FEEDBACK,
+)
 
 # Globals ###########################################################
 
@@ -16,6 +28,14 @@ loader = ResourceLoader(__name__)
 
 
 # Classes ###########################################################
+
+class ItemDefinition(object):
+    def __init__(self, item_id, zone_ids, zone_title, feedback_positive, feedback_negative):
+        self.feedback_negative = feedback_negative
+        self.feedback_positive = feedback_positive
+        self.zone_ids = zone_ids
+        self.zone_title = zone_title
+        self.item_id = item_id
 
 
 class BaseIntegrationTest(SeleniumBaseTest):
@@ -27,8 +47,14 @@ class BaseIntegrationTest(SeleniumBaseTest):
         "'": "&apos;"
     }
 
-    @staticmethod
-    def _make_scenario_xml(display_name, show_title, problem_text, completed=False, show_problem_header=True):
+    # pylint: disable=too-many-arguments
+    @classmethod
+    def _make_scenario_xml(
+        cls, display_name="Test DnDv2", show_title=True, problem_text="Question", completed=False,
+        show_problem_header=True, max_items_per_zone=0, data=None, mode=Constants.STANDARD_MODE
+    ):
+        if not data:
+            data = json.dumps(DEFAULT_DATA)
         return """
             <vertical_demo>
                 <drag-and-drop-v2
@@ -38,6 +64,9 @@ class BaseIntegrationTest(SeleniumBaseTest):
                     show_question_header='{show_problem_header}'
                     weight='1'
                     completed='{completed}'
+                    max_items_per_zone='{max_items_per_zone}'
+                    mode='{mode}'
+                    data='{data}'
                 />
             </vertical_demo>
         """.format(
@@ -46,6 +75,9 @@ class BaseIntegrationTest(SeleniumBaseTest):
             problem_text=escape(problem_text),
             show_problem_header=show_problem_header,
             completed=completed,
+            max_items_per_zone=max_items_per_zone,
+            mode=mode,
+            data=escape(data, cls._additional_escapes)
         )
 
     def _get_custom_scenario_xml(self, filename):
@@ -137,3 +169,263 @@ class BaseIntegrationTest(SeleniumBaseTest):
             return self.browser.execute_script("return typeof(jQuery)!='undefined' && jQuery.active==0")
 
         EmptyPromise(is_ajax_finished, "Finished waiting for ajax requests.", timeout=timeout).fulfill()
+
+
+class DefaultDataTestMixin(object):
+    """
+    Provides a test scenario with default options.
+    """
+    PAGE_TITLE = 'Drag and Drop v2'
+    PAGE_ID = 'drag_and_drop_v2'
+
+    items_map = {
+        0: ItemDefinition(
+            0, [TOP_ZONE_ID], TOP_ZONE_TITLE,
+            ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE), ITEM_INCORRECT_FEEDBACK
+        ),
+        1: ItemDefinition(
+            1, [MIDDLE_ZONE_ID], MIDDLE_ZONE_TITLE,
+            ITEM_CORRECT_FEEDBACK.format(zone=MIDDLE_ZONE_TITLE), ITEM_INCORRECT_FEEDBACK
+        ),
+        2: ItemDefinition(
+            2, [BOTTOM_ZONE_ID], BOTTOM_ZONE_TITLE,
+            ITEM_CORRECT_FEEDBACK.format(zone=BOTTOM_ZONE_TITLE), ITEM_INCORRECT_FEEDBACK
+        ),
+        3: ItemDefinition(
+            3, [MIDDLE_ZONE_ID, TOP_ZONE_ID, BOTTOM_ZONE_ID], MIDDLE_ZONE_TITLE,
+            ITEM_ANY_ZONE_FEEDBACK, ITEM_INCORRECT_FEEDBACK
+        ),
+        4: ItemDefinition(4, [], None, "", ITEM_NO_ZONE_FEEDBACK),
+    }
+
+    all_zones = [
+        (TOP_ZONE_ID, TOP_ZONE_TITLE),
+        (MIDDLE_ZONE_ID, MIDDLE_ZONE_TITLE),
+        (BOTTOM_ZONE_ID, BOTTOM_ZONE_TITLE)
+    ]
+
+    feedback = {
+        "intro": START_FEEDBACK,
+        "final": FINISH_FEEDBACK,
+    }
+
+    def _get_scenario_xml(self):  # pylint: disable=no-self-use
+        return "<vertical_demo><drag-and-drop-v2/></vertical_demo>"
+
+
+class InteractionTestBase(object):
+    @classmethod
+    def _get_items_with_zone(cls, items_map):
+        return {
+            item_key: definition for item_key, definition in items_map.items()
+            if definition.zone_ids != []
+        }
+
+    @classmethod
+    def _get_items_without_zone(cls, items_map):
+        return {
+            item_key: definition for item_key, definition in items_map.items()
+            if definition.zone_ids == []
+        }
+
+    @classmethod
+    def _get_items_by_zone(cls, items_map):
+        zone_ids = set([definition.zone_ids[0] for _, definition in items_map.items() if definition.zone_ids])
+        return {
+            zone_id: {item_key: definition for item_key, definition in items_map.items()
+                      if definition.zone_ids and definition.zone_ids[0] is zone_id}
+            for zone_id in zone_ids
+        }
+
+    def setUp(self):
+        super(InteractionTestBase, self).setUp()
+
+        scenario_xml = self._get_scenario_xml()
+        self._add_scenario(self.PAGE_ID, self.PAGE_TITLE, scenario_xml)
+        self._page = self.go_to_page(self.PAGE_TITLE)
+        # Resize window so that the entire drag container is visible.
+        # Selenium has issues when dragging to an area that is off screen.
+        self.browser.set_window_size(1024, 800)
+
+    def _get_item_by_value(self, item_value):
+        return self._page.find_elements_by_xpath(".//div[@data-value='{item_id}']".format(item_id=item_value))[0]
+
+    def _get_unplaced_item_by_value(self, item_value):
+        items_container = self._get_item_bank()
+        return items_container.find_elements_by_xpath(".//div[@data-value='{item_id}']".format(item_id=item_value))[0]
+
+    def _get_placed_item_by_value(self, item_value):
+        items_container = self._page.find_element_by_css_selector('.target')
+        return items_container.find_elements_by_xpath(".//div[@data-value='{item_id}']".format(item_id=item_value))[0]
+
+    def _get_zone_by_id(self, zone_id):
+        zones_container = self._page.find_element_by_css_selector('.target')
+        return zones_container.find_elements_by_xpath(".//div[@data-uid='{zone_id}']".format(zone_id=zone_id))[0]
+
+    def _get_dialog_components(self, dialog):  # pylint: disable=no-self-use
+        dialog_modal_overlay = dialog.find_element_by_css_selector('.modal-window-overlay')
+        dialog_modal = dialog.find_element_by_css_selector('.modal-window')
+        return dialog_modal_overlay, dialog_modal
+
+    def _get_dialog_dismiss_button(self, dialog_modal):  # pylint: disable=no-self-use
+        return dialog_modal.find_element_by_css_selector('.modal-dismiss-button')
+
+    def _get_item_bank(self):
+        return self._page.find_element_by_css_selector('.item-bank')
+
+    def _get_zone_position(self, zone_id):
+        return self.browser.execute_script(
+            'return $("div[data-uid=\'{zone_id}\']").prevAll(".zone").length'.format(zone_id=zone_id)
+        )
+
+    def _get_draggable_property(self, item_value):
+        """
+        Returns the value of the 'draggable' property of item.
+
+        Selenium has the element.get_attribute method that looks up properties and attributes,
+        but for some reason it *always* returns "true" for the 'draggable' property, event though
+        both the HTML attribute and the DOM property are set to false.
+        We work around that selenium bug by using JavaScript to get the correct value of 'draggable'.
+        """
+        script = "return $('div.option[data-value={}]').prop('draggable')".format(item_value)
+        return self.browser.execute_script(script)
+
+    def assertDraggable(self, item_value):
+        self.assertTrue(self._get_draggable_property(item_value))
+
+    def assertNotDraggable(self, item_value):
+        self.assertFalse(self._get_draggable_property(item_value))
+
+    @staticmethod
+    def wait_until_ondrop_xhr_finished(elem):
+        """
+        Waits until the XHR request triggered by dropping the item finishes loading.
+        """
+        wait = WebDriverWait(elem, 2)
+        # While the XHR is in progress, a spinner icon is shown inside the item.
+        # When the spinner disappears, we can assume that the XHR request has finished.
+        wait.until(
+            lambda e: 'fa-spinner' not in e.get_attribute('innerHTML'),
+            u"Spinner should not be in {}".format(elem.get_attribute('innerHTML'))
+        )
+
+    def place_item(self, item_value, zone_id, action_key=None):
+        """
+        Place item with ID of item_value into zone with ID of zone_id.
+        zone_id=None means place item back to the item bank.
+        action_key=None means simulate mouse drag/drop instead of placing the item with keyboard.
+        """
+        if action_key is None:
+            self.drag_item_to_zone(item_value, zone_id)
+        else:
+            self.move_item_to_zone(item_value, zone_id, action_key)
+        self.wait_for_ajax()
+
+    def drag_item_to_zone(self, item_value, zone_id):
+        """
+        Drag item to desired zone using mouse interaction.
+        zone_id=None means drag item back to the item bank.
+        """
+        element = self._get_item_by_value(item_value)
+        if zone_id is None:
+            target = self._get_item_bank()
+        else:
+            target = self._get_zone_by_id(zone_id)
+        action_chains = ActionChains(self.browser)
+        action_chains.drag_and_drop(element, target).perform()
+
+    def move_item_to_zone(self, item_value, zone_id, action_key):
+        """
+        Place item to descired zone using keybard interaction.
+        zone_id=None means place item back into the item bank.
+        """
+        # Focus on the item, then press the action key:
+        item = self._get_item_by_value(item_value)
+        item.send_keys("")
+        item.send_keys(action_key)
+        # Focus is on first *zone* now
+        self.assert_grabbed_item(item)
+        # Get desired zone and figure out how many times we have to press Tab to focus the zone.
+        if zone_id is None:  # moving back to the bank
+            zone = self._get_item_bank()
+            # When switching focus between zones in keyboard placement mode,
+            # the item bank always gets focused last (after all regular zones),
+            # so we have to press Tab once for every regular zone to move focus to the item bank.
+            tab_press_count = len(self.all_zones)
+        else:
+            zone = self._get_zone_by_id(zone_id)
+            # The number of times we have to press Tab to focus the desired zone equals the zero-based
+            # position of the zone (zero presses for first zone, one press for second zone, etc).
+            tab_press_count = self._get_zone_position(zone_id)
+        for _ in range(tab_press_count):
+            ActionChains(self.browser).send_keys(Keys.TAB).perform()
+        zone.send_keys(action_key)
+
+    def assert_grabbed_item(self, item):
+        self.assertEqual(item.get_attribute('aria-grabbed'), 'true')
+
+    def assert_placed_item(self, item_value, zone_title, assessment_mode=False):
+        item = self._get_placed_item_by_value(item_value)
+        self.wait_until_visible(item)
+        self.wait_until_ondrop_xhr_finished(item)
+        item_content = item.find_element_by_css_selector('.item-content')
+        self.wait_until_visible(item_content)
+        item_description = item.find_element_by_css_selector('.sr')
+        self.wait_until_visible(item_description)
+        item_description_id = '-item-{}-description'.format(item_value)
+
+        self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
+        self.assertEqual(item_content.get_attribute('aria-describedby'), item_description_id)
+        self.assertEqual(item_description.get_attribute('id'), item_description_id)
+        if assessment_mode:
+            self.assertDraggable(item_value)
+            self.assertEqual(item.get_attribute('class'), 'option')
+            self.assertEqual(item.get_attribute('tabindex'), '0')
+            self.assertEqual(item_description.text, 'Placed in: {}'.format(zone_title))
+        else:
+            self.assertNotDraggable(item_value)
+            self.assertEqual(item.get_attribute('class'), 'option fade')
+            self.assertIsNone(item.get_attribute('tabindex'))
+            self.assertEqual(item_description.text, 'Correctly placed in: {}'.format(zone_title))
+
+    def assert_reverted_item(self, item_value):
+        item = self._get_item_by_value(item_value)
+        self.wait_until_visible(item)
+        self.wait_until_ondrop_xhr_finished(item)
+        item_content = item.find_element_by_css_selector('.item-content')
+
+        self.assertDraggable(item_value)
+        self.assertEqual(item.get_attribute('class'), 'option')
+        self.assertEqual(item.get_attribute('tabindex'), '0')
+        self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
+        item_description_id = '-item-{}-description'.format(item_value)
+        self.assertEqual(item_content.get_attribute('aria-describedby'), item_description_id)
+
+        describedby_text = (u'Press "Enter", "Space", "Ctrl-m", or "⌘-m" on an item to select it for dropping, '
+                            'then navigate to the zone you want to drop it on.')
+        self.assertEqual(item.find_element_by_css_selector('.sr').text, describedby_text)
+
+    def place_decoy_items(self, items_map, action_key):
+        decoy_items = self._get_items_without_zone(items_map)
+        # Place decoy items into first available zone.
+        zone_id, zone_title = self.all_zones[0]
+        for definition in decoy_items.values():
+            self.place_item(definition.item_id, zone_id, action_key)
+            self.assert_placed_item(definition.item_id, zone_title, assessment_mode=True)
+
+    def assert_decoy_items(self, items_map, assessment_mode=False):
+        decoy_items = self._get_items_without_zone(items_map)
+        for item_key in decoy_items:
+            item = self._get_item_by_value(item_key)
+            self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
+            if assessment_mode:
+                self.assertDraggable(item_key)
+                self.assertEqual(item.get_attribute('class'), 'option')
+            else:
+                self.assertNotDraggable(item_key)
+                self.assertEqual(item.get_attribute('class'), 'option fade')
+
+    def _switch_to_block(self, idx):
+        """ Only needed if there are multiple blocks on the page. """
+        self._page = self.browser.find_elements_by_css_selector(self.default_css_selector)[idx]
+        self.scroll_down(0)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,76 @@
+from ddt import ddt, data, unpack
+from mock import Mock, patch
+from workbench.runtime import WorkbenchRuntime
+
+from drag_and_drop_v2.default_data import TOP_ZONE_TITLE, TOP_ZONE_ID, ITEM_CORRECT_FEEDBACK
+
+from .test_base import BaseIntegrationTest, DefaultDataTestMixin
+from .test_interaction import ParameterizedTestsMixin
+from tests.integration.test_base import InteractionTestBase
+
+
+@ddt
+class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, InteractionTestBase, BaseIntegrationTest):
+    """
+    Tests that the analytics events are fired and in the proper order.
+    """
+    # These events must be fired in this order.
+    scenarios = (
+        {
+            'name': 'edx.drag_and_drop_v2.loaded',
+            'data': {},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.picked_up',
+            'data': {'item_id': 0},
+        },
+        {
+            'name': 'grade',
+            'data': {'max_value': 1, 'value': (2.0 / 5)},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.dropped',
+            'data': {
+                'is_correct': True,
+                'item_id': 0,
+                'location': TOP_ZONE_TITLE,
+                'location_id': TOP_ZONE_ID,
+            },
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.feedback.opened',
+            'data': {
+                'content': ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE),
+                'truncated': False,
+            },
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.feedback.closed',
+            'data': {
+                'manually': False,
+                'content': ITEM_CORRECT_FEEDBACK.format(zone=TOP_ZONE_TITLE),
+                'truncated': False,
+            },
+        },
+    )
+
+    def setUp(self):
+        mock = Mock()
+        context = patch.object(WorkbenchRuntime, 'publish', mock)
+        context.start()
+        self.addCleanup(context.stop)
+        self.publish = mock
+        super(EventsFiredTest, self).setUp()
+
+    def _get_scenario_xml(self):  # pylint: disable=no-self-use
+        return "<vertical_demo><drag-and-drop-v2/></vertical_demo>"
+
+    @data(*enumerate(scenarios))  # pylint: disable=star-args
+    @unpack
+    def test_event(self, index, event):
+        self.parameterized_item_positive_feedback_on_good_move(self.items_map)
+        dummy, name, published_data = self.publish.call_args_list[index][0]
+        self.assertEqual(name, event['name'])
+        self.assertEqual(
+                published_data, event['data']
+        )

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -189,7 +189,7 @@ class TestDragAndDropRender(BaseIntegrationTest):
             self.assertEqual(zone.get_attribute('dropzone'), 'move')
             self.assertEqual(zone.get_attribute('aria-dropeffect'), 'move')
             self.assertEqual(zone.get_attribute('data-uid'), 'Zone {}'.format(zone_number))
-            self.assertEqual(zone.get_attribute('data-zone_align'), 'none')
+            self.assertEqual(zone.get_attribute('data-zone_align'), 'center')
             self.assertIn('ui-droppable', self.get_element_classes(zone))
             zone_box_percentages = box_percentages[index]
             self._assert_box_percentages(  # pylint: disable=star-args
@@ -293,8 +293,8 @@ class TestDragAndDropRenderZoneAlign(BaseIntegrationTest):
 
     def test_zone_align(self):
         expected_alignments = {
-            "#-Zone_No_Align": "start",
-            "#-Zone_Invalid_Align": "start",
+            "#-Zone_No_Align": "center",
+            "#-Zone_Invalid_Align": "center",
             "#-Zone_Left_Align": "left",
             "#-Zone_Right_Align": "right",
             "#-Zone_Center_Align": "center"

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -8,7 +8,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from xblockutils.resources import ResourceLoader
 
 from .test_base import BaseIntegrationTest
-from .test_interaction import InteractionTestBase
+from tests.integration.test_base import InteractionTestBase
 
 loader = ResourceLoader(__name__)
 
@@ -82,7 +82,7 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
     EXPECTATIONS = [
         # The text 'Auto' with no fixed size specified should be 5-20% wide
-        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[5, 20]),
+        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[5, AUTO_MAX_WIDTH]),
         # The long text with no fixed size specified should be wrapped at the maximum width
         Expectation(item_id=1, zone_id=ZONE_33, width_percent=AUTO_MAX_WIDTH),
         # The text items that specify specific widths as a percentage of the background image:

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -13,6 +13,7 @@
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "test",
+    "max_items_per_zone": null,
 
     "zones": [
         {
@@ -21,7 +22,8 @@
           "x": 234,
           "width": 345,
           "height": 456,
-          "uid": "zone-1"
+          "uid": "zone-1",
+          "align": "right"
         },
         {
           "title": "Zone 2",
@@ -29,7 +31,8 @@
           "x": 10,
           "width": 30,
           "height": 40,
-          "uid": "zone-2"
+          "uid": "zone-2",
+          "align": "center"
         }
     ],
 

--- a/tests/unit/data/assessment/data.json
+++ b/tests/unit/data/assessment/data.json
@@ -6,7 +6,8 @@
       "x": 234,
       "width": 345,
       "height": 456,
-      "uid": "zone-1"
+      "uid": "zone-1",
+      "align": "right"
     },
     {
       "title": "Zone 2",

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -13,6 +13,7 @@
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "unique_name",
+    "max_items_per_zone": null,
 
     "zones": [
         {
@@ -21,7 +22,8 @@
           "y": 200,
           "width": 200,
           "height": 100,
-          "uid": "Zone <i>1</i>"
+          "uid": "Zone <i>1</i>",
+          "align": "right"
         },
         {
           "title": "Zone <b>2</b>",
@@ -29,7 +31,8 @@
           "y": 0,
           "width": 200,
           "height": 100,
-          "uid": "Zone <b>2</b>"
+          "uid": "Zone <b>2</b>",
+          "align": "center"
         }
     ],
 

--- a/tests/unit/data/html/data.json
+++ b/tests/unit/data/html/data.json
@@ -7,7 +7,8 @@
       "height": 100,
       "y": 200,
       "x": 100,
-      "id": "zone-1"
+      "id": "zone-1",
+      "align": "right"
     },
     {
       "index": 2,
@@ -16,7 +17,8 @@
       "height": 100,
       "y": 0,
       "x": 0,
-      "id": "zone-2"
+      "id": "zone-2",
+      "align": "center"
     }
   ],
 

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -13,6 +13,7 @@
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "",
+    "max_items_per_zone": null,
 
     "zones": [
         {
@@ -21,7 +22,8 @@
           "y": "200",
           "width": 200,
           "height": 100,
-          "uid": "Zone 1"
+          "uid": "Zone 1",
+          "align": "center"
         },
         {
           "title": "Zone 2",
@@ -29,7 +31,8 @@
           "y": 0,
           "width": 200,
           "height": 100,
-          "uid": "Zone 2"
+          "uid": "Zone 2",
+          "align": "center"
         }
     ],
 

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -13,6 +13,7 @@
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "test",
+    "max_items_per_zone": 4,
 
     "zones": [
         {
@@ -21,7 +22,8 @@
           "x": 234,
           "width": 345,
           "height": 456,
-          "uid": "zone-1"
+          "uid": "zone-1",
+          "align": "left"
         },
         {
           "title": "Zone 2",
@@ -29,7 +31,8 @@
           "x": 10,
           "width": 30,
           "height": 40,
-          "uid": "zone-2"
+          "uid": "zone-2",
+          "align": "center"
         }
     ],
 

--- a/tests/unit/data/plain/data.json
+++ b/tests/unit/data/plain/data.json
@@ -6,7 +6,8 @@
       "x": 234,
       "width": 345,
       "height": 456,
-      "uid": "zone-1"
+      "uid": "zone-1",
+      "align": "left"
     },
     {
       "title": "Zone 2",
@@ -14,7 +15,8 @@
       "x": 10,
       "width": 30,
       "height": 40,
-      "uid": "zone-2"
+      "uid": "zone-2",
+      "align": "center"
     }
   ],
 

--- a/tests/unit/data/plain/settings.json
+++ b/tests/unit/data/plain/settings.json
@@ -7,5 +7,6 @@
     "weight": 1,
     "item_background_color": "",
     "item_text_color": "",
-    "url_name": "test"
+    "url_name": "test",
+    "max_items_per_zone": 4
 }

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -75,7 +75,7 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
     """
     def test_drop_item_wrong_with_feedback(self):
         item_id, zone_id = 0, self.ZONE_2
-        data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
+        data = {"val": item_id, "zone": zone_id}
         res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
             "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
@@ -86,7 +86,7 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
 
     def test_drop_item_wrong_without_feedback(self):
         item_id, zone_id = 2, self.ZONE_1
-        data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
+        data = {"val": item_id, "zone": zone_id}
         res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
             "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
@@ -97,7 +97,7 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
 
     def test_drop_item_correct(self):
         item_id, zone_id = 0, self.ZONE_1
-        data = {"val": item_id, "zone": zone_id, "x_percent": "33%", "y_percent": "11%"}
+        data = {"val": item_id, "zone": zone_id}
         res = self.call_handler(self.DROP_ITEM_HANDLER, data)
         self.assertEqual(res, {
             "overall_feedback": [self._make_feedback_message(message=self.INITIAL_FEEDBACK)],
@@ -114,27 +114,23 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
                 published_grades.append(params)
         self.block.runtime.publish = mock_publish
 
-        self.call_handler(self.DROP_ITEM_HANDLER, {
-            "val": 0, "zone": self.ZONE_1, "y_percent": "11%", "x_percent": "33%"
-        })
+        self.call_handler(self.DROP_ITEM_HANDLER, {"val": 0, "zone": self.ZONE_1})
 
         self.assertEqual(1, len(published_grades))
         self.assertEqual({'value': 0.75, 'max_value': 1}, published_grades[-1])
 
-        self.call_handler(self.DROP_ITEM_HANDLER, {
-            "val": 1, "zone": self.ZONE_2, "y_percent": "90%", "x_percent": "42%"
-        })
+        self.call_handler(self.DROP_ITEM_HANDLER, {"val": 1, "zone": self.ZONE_2})
 
         self.assertEqual(2, len(published_grades))
         self.assertEqual({'value': 1, 'max_value': 1}, published_grades[-1])
 
     def test_drop_item_final(self):
-        data = {"val": 0, "zone": self.ZONE_1, "x_percent": "33%", "y_percent": "11%"}
+        data = {"val": 0, "zone": self.ZONE_1}
         self.call_handler(self.DROP_ITEM_HANDLER, data)
 
         expected_state = {
             "items": {
-                "0": {"x_percent": "33%", "y_percent": "11%", "correct": True, "zone": self.ZONE_1}
+                "0": {"correct": True, "zone": self.ZONE_1}
             },
             "finished": False,
             "attempts": 0,
@@ -142,8 +138,7 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
         }
         self.assertEqual(expected_state, self.call_handler('get_user_state', method="GET"))
 
-        data = {"val": 1, "zone": self.ZONE_2, "x_percent": "22%", "y_percent": "22%"}
-        res = self.call_handler(self.DROP_ITEM_HANDLER, data)
+        res = self.call_handler(self.DROP_ITEM_HANDLER, {"val": 1, "zone": self.ZONE_2})
         self.assertEqual(res, {
             "overall_feedback": [self._make_feedback_message(message=self.FINAL_FEEDBACK)],
             "finished": True,
@@ -153,12 +148,8 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
 
         expected_state = {
             "items": {
-                "0": {
-                    "x_percent": "33%", "y_percent": "11%", "correct": True, "zone": self.ZONE_1,
-                },
-                "1": {
-                    "x_percent": "22%", "y_percent": "22%", "correct": True, "zone": self.ZONE_2,
-                }
+                "0": {"correct": True, "zone": self.ZONE_1},
+                "1": {"correct": True, "zone": self.ZONE_2}
             },
             "finished": True,
             "attempts": 0,
@@ -182,9 +173,7 @@ class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
     """
     @staticmethod
     def _make_submission(item_id, zone_id):
-        x_percent, y_percent = str(random.randint(0, 100)) + '%', str(random.randint(0, 100)) + '%'
-        data = {"val": item_id, "zone": zone_id, "x_percent": x_percent, "y_percent": y_percent}
-        return data
+        return {"val": item_id, "zone": zone_id}
 
     def _submit_solution(self, solution):
         for item_id, zone_id in solution.iteritems():
@@ -209,12 +198,11 @@ class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
         item_zone_map = {0: self.ZONE_1, 1: self.ZONE_2}
         for item_id, zone_id in item_zone_map.iteritems():
             data = self._make_submission(item_id, zone_id)
-            x_percent, y_percent = data['x_percent'], data['y_percent']
             res = self.call_handler(self.DROP_ITEM_HANDLER, data)
 
             self.assertEqual(res, {})
 
-            expected_item_state = {'zone': zone_id, 'correct': True, 'x_percent': x_percent, 'y_percent': y_percent}
+            expected_item_state = {'zone': zone_id, 'correct': True}
 
             self.assertIn(str(item_id), self.block.item_state)
             self.assertEqual(self.block.item_state[str(item_id)], expected_item_state)


### PR DESCRIPTION
**Description:** This PR updates item placement logic:

* Zone alignment "none" (aka no alignment) is removed, dropped items always use the "aligned" layout option rather than being placed where the learner dropped them.
* "Max items per zone" setting added to allow limiting max number of items dropped into a single zone - course authors can use this setting to provide some kind of a hint, or to prevent visual overflow when too many items are dropped into single zone.

**JIRA:** [SOL-1979](https://openedx.atlassian.net/browse/SOL-1979)

**Discussions:** [SOL-1979](https://openedx.atlassian.net/browse/SOL-1979) and https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/83#issuecomment-236017205

**Sandboxes:**

* LMS: http://dndv2-sandbox9.opencraft.hosting/
* Studio: http://studio-dndv2-sandbox9.opencraft.hosting/


**Note:** at the moment #86 was merged, but #87 was not, and this PR does not include changes from #87; as a result, DnDv2 on sandbox show "Submit" button, but it does not do anything - this is an expected behavior until #87 is merged

**Testing instructions:**

Items alignment:
1. Open new or existing DnDv2 block in studio, open editor, go to "Zones" tab. *Expected:* zone "Alignment" dropdown does not have "none" option; default is "center"
2. Open DnDv2 XBlock in LMS.
3. Make sure that items dropped into a zone are aligned according to zone alignment configuration.
4. Existing zones with "none" alignment should be treated as having "center"alignment; this should be the case even if an XBlock was not updated in Studio after this PR is applied.

Max items per zone:
1. Open new or existing DnDv2 block in studio, open editor, go to "Items" tab. *Expected:* "Max items per zone" is displayed.
2. Setting "max items per zone" to ~~zero or~~ empty string has no further effect (make sure you can put as much items into a single dropzone as you wish in LMS)
3. Setting "max items per zone" to zero or negative value ~~should cause validation errors~~ will result in value being set to empty string
4. ~~Setting "max items per zone" to positive value will validate item placement. If any zone has more "correct" items than "max items per zone" a validation error will be shown, and XBlock will not be updated.~~
5. After setting "max items per zone" to positive value ~~and passing the validation~~, publish the unit and open it in LMS. *Expected:* can only put up to "max items per zone" items into a single zone.
6. *Note:* existing answers are not updated, so it is possible to have more than "max items per zone" items dropped into a single zone if "max items" setting changed after the answer was submitted.

**Screenshots:**

Studio "Zones" tab:

![image](https://cloud.githubusercontent.com/assets/3330048/17551549/79ba91d6-5f03-11e6-93ce-72042a44b884.png)

Studio "Items" tab:

![image](https://cloud.githubusercontent.com/assets/3330048/17770812/67533cc8-6548-11e6-8aa6-c996b833ee53.png)

<!-- With validation errors: -->

<!-- ![image](https://cloud.githubusercontent.com/assets/3330048/17782607/1b27990e-657d-11e6-8d1f-07b01b2caef1.png) -->

LMS - item alignment:

![image](https://cloud.githubusercontent.com/assets/3330048/17551802/d18e97d0-5f04-11e6-8ed2-467a9352ed05.png)

Attempting to exceed max items per zone:

![image](https://cloud.githubusercontent.com/assets/3330048/17551840/06e31b68-5f05-11e6-9f80-e39ae9363337.png)

**Reviewers:**
- [x] @itsjeyd 
- [x] TNL: @cahrens and/or @staubina
- [ ] ~~a11y: @cptvitamin~~  a11y review will be performed later, for all changes in v2.1: [SOL-1978](https://openedx.atlassian.net/browse/SOL-1978)
- [x] Product: @sstack22

**Checklist:**
- [x] Internal review
- [x] Upstream review
- [x] Squash commits