### PR TITLE
Assessment mode: display item feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ image. You can define custom success and error feedback for each item. In
 standard mode, the feedback text is displayed in a popup after the learner drops
 the item on a zone - the success feedback is shown if the item is dropped on a
 correct zone, while the error feedback is shown when dropping the item on an
-incorrect drop zone.  In assessment mode, the success and error feedback texts
-are not used.
+incorrect drop zone.  In assessment mode, the success feedback texts
+are not used, while error feedback texts are shown when learner submits a solution.
 
 You can select any number of zones for an item to belong to using
 the checkboxes; all zones defined in the previous step are available.

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -356,13 +356,11 @@
 
 .xblock--drag-and-drop .popup .popup-content {
     color: #ffffff;
-    margin-left: 15px;
-    margin-top: 35px;
-    margin-bottom: 15px;
+    margin: 35px 15px 15px 15px;
     font-size: 14px;
 }
 
-.xblock--drag-and-drop .popup .close {
+.xblock--drag-and-drop .popup .close-feedback-popup-button {
     cursor: pointer;
     float: right;
     margin-right: 8px;
@@ -373,7 +371,7 @@
     font-size: 18pt;
 }
 
-.xblock--drag-and-drop .popup .close:focus {
+.xblock--drag-and-drop .popup .close-feedback-popup-button:focus {
     outline: 2px solid white;
 }
 

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -499,6 +499,10 @@ msgstr ""
 msgid "You have used {used} of {total} attempts."
 msgstr ""
 
+#: public/js/drag_and_drop.js
+msgid "Some of your answers were not correct."
+msgstr ""
+
 #: public/js/drag_and_drop_edit.js
 msgid "There was an error with your form."
 msgstr ""
@@ -511,12 +515,12 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: utils.py:18
-msgid "Final attempt was used, highest score is {score}"
+#: public/js/drag_and_drop_edit.js
+msgid "Close item feedback popup"
 msgstr ""
 
-#: utils.py:19
-msgid "Misplaced items were returned to item bank."
+#: utils.py:18
+msgid "Final attempt was used, highest score is {score}"
 msgstr ""
 
 #: utils.py:24
@@ -526,8 +530,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: utils.py:32
-msgid "Misplaced {misplaced_count} item."
-msgid_plural "Misplaced {misplaced_count} items."
+msgid "Misplaced {misplaced_count} item. Misplaced item was returned to item bank."
+msgid_plural "Misplaced {misplaced_count} items. Misplaced items were returned to item bank."
 msgstr[0] ""
 msgstr[1] ""
 

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -585,6 +585,10 @@ msgstr ""
 msgid "You have used {used} of {total} attempts."
 msgstr "Ýöü hävé üséd {used} öf {total} ättémpts. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
 
+#: public/js/drag_and_drop.js
+msgid "Some of your answers were not correct."
+msgstr "Sömé öf ýöür änswérs wéré nöt cörréct. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєт#"
+
 #: public/js/drag_and_drop_edit.js
 msgid "There was an error with your form."
 msgstr ""
@@ -599,28 +603,28 @@ msgstr ""
 msgid "None"
 msgstr "Nöné Ⱡ'σяєм ι#"
 
-#: utils.py:18
-msgid "Fïnäl ättémpt wäs üséd, hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
-msgstr ""
+#: public/js/drag_and_drop_edit.js
+msgid "Close item feedback popup"
+msgstr "Çlösé ïtém féédßäçk pöpüp Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
-#: utils.py:19
-msgid "Mïspläçéd ïtéms wéré rétürnéd tö ïtém ßänk. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
-msgstr ""
+#: utils.py:18
+msgid "Final attempt was used, highest score is {score}"
+msgstr "Fïnäl ättémpt wäs üséd, hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 
 #: utils.py:24
-msgid "Çörréçtlý pläçéd {correct_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
-msgid_plural "Çörréçtlý pläçéd {correct_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Correctly placed {correct_count} item."
+msgid_plural "Correctly placed {correct_count} items."
+msgstr[0] "Çörréçtlý pläçéd {correct_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
+msgstr[1] "Çörréçtlý pläçéd {correct_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
 
 #: utils.py:32
-msgid "Mïspläçéd {misplaced_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
-msgid_plural "Mïspläçéd {misplaced_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Misplaced {misplaced_count} item. Misplaced item was returned to item bank."
+msgid_plural "Misplaced {misplaced_count} items. Misplaced items were returned to item bank."
+msgstr[0] "Mïspläçéd {misplaced_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
+msgstr[1] "Mïspläçéd {misplaced_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
 
 #: utils.py:40
-msgid "Dïd nöt pläçé {missing_count} réqüïréd ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
-msgid_plural "Dïd nöt pläçé {missing_count} réqüïréd ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
-msgstr[0] ""
-msgstr[1] ""
+msgid "Did not place {missing_count} required item."
+msgid_plural "Did not place {missing_count} required items."
+msgstr[0] "Dïd nöt pläçé {missing_count} réqüïréd ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
+msgstr[1] "Dïd nöt pläçé {missing_count} réqüïréd ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"

--- a/drag_and_drop_v2/utils.py
+++ b/drag_and_drop_v2/utils.py
@@ -42,7 +42,6 @@ class FeedbackMessages(object):
         NOT_PLACED = INCORRECT_SOLUTION
 
     FINAL_ATTEMPT_TPL = _('Final attempt was used, highest score is {score}')
-    MISPLACED_ITEMS_RETURNED = _('Misplaced item(s) were returned to item bank.')
 
     @staticmethod
     def correctly_placed(number, ngettext=ngettext_fallback):

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -214,6 +214,8 @@ class DefaultDataTestMixin(object):
 
 
 class InteractionTestBase(object):
+    POPUP_ERROR_CLASS = "popup-incorrect"
+
     @classmethod
     def _get_items_with_zone(cls, items_map):
         return {
@@ -309,7 +311,7 @@ class InteractionTestBase(object):
             u"Spinner should not be in {}".format(elem.get_attribute('innerHTML'))
         )
 
-    def place_item(self, item_value, zone_id, action_key=None):
+    def place_item(self, item_value, zone_id, action_key=None, wait=True):
         """
         Place item with ID of item_value into zone with ID of zone_id.
         zone_id=None means place item back to the item bank.
@@ -319,7 +321,8 @@ class InteractionTestBase(object):
             self.drag_item_to_zone(item_value, zone_id)
         else:
             self.move_item_to_zone(item_value, zone_id, action_key)
-        self.wait_for_ajax()
+        if wait:
+            self.wait_for_ajax()
 
     def drag_item_to_zone(self, item_value, zone_id):
         """
@@ -429,3 +432,12 @@ class InteractionTestBase(object):
         """ Only needed if there are multiple blocks on the page. """
         self._page = self.browser.find_elements_by_css_selector(self.default_css_selector)[idx]
         self.scroll_down(0)
+
+    def assert_popup_correct(self, popup):
+        self.assertNotIn(self.POPUP_ERROR_CLASS, popup.get_attribute('class'))
+
+    def assert_popup_incorrect(self, popup):
+        self.assertIn(self.POPUP_ERROR_CLASS, popup.get_attribute('class'))
+
+    def assert_button_enabled(self, submit_button, enabled=True):
+        self.assertEqual(submit_button.is_enabled(), enabled)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,16 +1,28 @@
-from ddt import ddt, data, unpack
+from ddt import data, ddt, unpack
 from mock import Mock, patch
+
 from workbench.runtime import WorkbenchRuntime
 
-from drag_and_drop_v2.default_data import TOP_ZONE_TITLE, TOP_ZONE_ID, ITEM_CORRECT_FEEDBACK
+from drag_and_drop_v2.default_data import (
+    TOP_ZONE_TITLE, TOP_ZONE_ID, MIDDLE_ZONE_TITLE, MIDDLE_ZONE_ID, ITEM_CORRECT_FEEDBACK, ITEM_INCORRECT_FEEDBACK
+)
+from tests.integration.test_base import BaseIntegrationTest, DefaultDataTestMixin, InteractionTestBase
+from tests.integration.test_interaction import DefaultDataTestMixin, ParameterizedTestsMixin
+from tests.integration.test_interaction_assessment import DefaultAssessmentDataTestMixin, AssessmentTestMixin
 
-from .test_base import BaseIntegrationTest, DefaultDataTestMixin
-from .test_interaction import ParameterizedTestsMixin
-from tests.integration.test_base import InteractionTestBase
+
+class BaseEventsTests(InteractionTestBase, BaseIntegrationTest):
+    def setUp(self):
+        mock = Mock()
+        context = patch.object(WorkbenchRuntime, 'publish', mock)
+        context.start()
+        self.addCleanup(context.stop)
+        self.publish = mock
+        super(BaseEventsTests, self).setUp()
 
 
 @ddt
-class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, InteractionTestBase, BaseIntegrationTest):
+class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, BaseEventsTests):
     """
     Tests that the analytics events are fired and in the proper order.
     """
@@ -54,14 +66,6 @@ class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, Interaction
         },
     )
 
-    def setUp(self):
-        mock = Mock()
-        context = patch.object(WorkbenchRuntime, 'publish', mock)
-        context.start()
-        self.addCleanup(context.stop)
-        self.publish = mock
-        super(EventsFiredTest, self).setUp()
-
     def _get_scenario_xml(self):  # pylint: disable=no-self-use
         return "<vertical_demo><drag-and-drop-v2/></vertical_demo>"
 
@@ -71,6 +75,68 @@ class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, Interaction
         self.parameterized_item_positive_feedback_on_good_move(self.items_map)
         dummy, name, published_data = self.publish.call_args_list[index][0]
         self.assertEqual(name, event['name'])
-        self.assertEqual(
-                published_data, event['data']
-        )
+        self.assertEqual(published_data, event['data'])
+
+
+@ddt
+class AssessmentEventsFiredTest(
+    DefaultAssessmentDataTestMixin, AssessmentTestMixin, BaseEventsTests
+):
+    scenarios = (
+        {
+            'name': 'edx.drag_and_drop_v2.loaded',
+            'data': {},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.picked_up',
+            'data': {'item_id': 0},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.dropped',
+            'data': {
+                'is_correct': False,
+                'item_id': 0,
+                'location': MIDDLE_ZONE_TITLE,
+                'location_id': MIDDLE_ZONE_ID,
+            },
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.picked_up',
+            'data': {'item_id': 1},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.item.dropped',
+            'data': {
+                'is_correct': False,
+                'item_id': 1,
+                'location': TOP_ZONE_TITLE,
+                'location_id': TOP_ZONE_ID,
+            },
+        },
+        {
+            'name': 'grade',
+            'data': {'max_value': 1, 'value': (1.0 / 5)},
+        },
+        {
+            'name': 'edx.drag_and_drop_v2.feedback.opened',
+            'data': {
+                'content': "\n".join([ITEM_INCORRECT_FEEDBACK, ITEM_INCORRECT_FEEDBACK]),
+                'truncated': False,
+            },
+        },
+    )
+
+    def test_event(self):
+        self.scroll_down(pixels=100)
+
+        self.place_item(0, MIDDLE_ZONE_ID)
+        self.wait_until_ondrop_xhr_finished(self._get_item_by_value(0))
+        self.place_item(1, TOP_ZONE_ID)
+        self.wait_until_ondrop_xhr_finished(self._get_item_by_value(0))
+
+        self.click_submit()
+        self.wait_for_ajax()
+        for index, event in enumerate(self.scenarios):
+            dummy, name, published_data = self.publish.call_args_list[index][0]
+            self.assertEqual(name, event['name'])
+            self.assertEqual(published_data, event['data'])

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -42,8 +42,8 @@ class ParameterizedTestsMixin(object):
                 self.assertEqual(feedback_popup_html, '')
                 self.assertFalse(popup.is_displayed())
             else:
-                self.assertEqual(feedback_popup_html, definition.feedback_positive)
-                self.assertEqual(popup.get_attribute('class'), 'popup')
+                self.assertEqual(feedback_popup_html, "<p>{}</p>".format(definition.feedback_positive))
+                self.assert_popup_correct(popup)
                 self.assertTrue(popup.is_displayed())
 
     def parameterized_item_negative_feedback_on_bad_move(
@@ -74,7 +74,7 @@ class ParameterizedTestsMixin(object):
                     self.assert_placed_item(definition.item_id, zone_title, assessment_mode=True)
                 else:
                     self.wait_until_html_in(definition.feedback_negative, feedback_popup_content)
-                    self.assertEqual(popup.get_attribute('class'), 'popup popup-incorrect')
+                    self.assert_popup_incorrect(popup)
                     self.assertTrue(popup.is_displayed())
                     self.assert_reverted_item(definition.item_id)
 
@@ -288,7 +288,7 @@ class MultipleValidOptionsInteractionTest(DefaultDataTestMixin, InteractionTestB
             for i, zone in enumerate(item.zone_ids):
                 self.place_item(item.item_id, zone, None)
                 self.wait_until_html_in(item.feedback_positive[i], feedback_popup_content)
-                self.assertEqual(popup.get_attribute('class'), 'popup')
+                self.assert_popup_correct(popup)
                 self.assert_placed_item(item.item_id, item.zone_title[i])
                 reset.click()
                 self.wait_until_disabled(reset)
@@ -534,12 +534,15 @@ class TestMaxItemsPerZone(InteractionTestBase, BaseIntegrationTest):
         self.assertTrue(feedback_popup.is_displayed())
 
         feedback_popup_content = self._get_popup_content()
-        self.assertEqual(
-            feedback_popup_content.get_attribute('innerHTML'),
-            "You cannot add any more items to this zone."
+        self.assertIn(
+            "You cannot add any more items to this zone.",
+            feedback_popup_content.get_attribute('innerHTML')
         )
 
     def test_item_returned_to_bank_after_refresh(self):
+        """
+        Tests that an item returned to the bank stays there after page refresh
+        """
         zone_id = "Zone Left Align"
         self.place_item(6, zone_id)
         self.place_item(7, zone_id)

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -209,7 +209,7 @@ class TestDragAndDropRender(BaseIntegrationTest):
         popup_wrapper = self._get_popup_wrapper()
         popup_content = self._get_popup_content()
         self.assertFalse(popup.is_displayed())
-        self.assertEqual(popup.get_attribute('class'), 'popup')
+        self.assertIn('popup', popup.get_attribute('class'))
         self.assertEqual(popup_content.text, "")
         self.assertEqual(popup_wrapper.get_attribute('aria-live'), 'polite')
 

--- a/tests/integration/test_title_and_question.py
+++ b/tests/integration/test_title_and_question.py
@@ -26,7 +26,7 @@ class TestDragAndDropTitleAndProblem(BaseIntegrationTest):
         self.addCleanup(scenarios.remove_scenario, const_page_id)
 
         page = self.go_to_page(const_page_name)
-        is_problem_header_visible = len(page.find_elements_by_css_selector('section.problem > h3')) > 0
+        is_problem_header_visible = len(page.find_elements_by_css_selector('section.problem > h4')) > 0
         self.assertEqual(is_problem_header_visible, show_problem_header)
 
         problem = page.find_element_by_css_selector('section.problem > p')
@@ -52,8 +52,8 @@ class TestDragAndDropTitleAndProblem(BaseIntegrationTest):
 
         page = self.go_to_page(const_page_name)
         if show_title:
-            problem_header = page.find_element_by_css_selector('h2.problem-title')
+            problem_header = page.find_element_by_css_selector('h3.problem-title')
             self.assertEqual(self.get_element_html(problem_header), display_name)
         else:
             with self.assertRaises(NoSuchElementException):
-                page.find_element_by_css_selector('h2.problem-title')
+                page.find_element_by_css_selector('h3.problem-title')

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -9,7 +9,6 @@
     "target_img_description": "This describes the target image",
     "item_background_color": null,
     "item_text_color": null,
-    "initial_feedback": "This is the initial feedback.",
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "test",

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -9,7 +9,6 @@
     "target_img_description": "This describes the target image",
     "item_background_color": "white",
     "item_text_color": "#000080",
-    "initial_feedback": "HTML <strong>Intro</strong> Feed",
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "unique_name",

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -9,7 +9,6 @@
     "target_img_description": "This describes the target image",
     "item_background_color": null,
     "item_text_color": null,
-    "initial_feedback": "Intro Feed",
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "",

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -9,7 +9,6 @@
     "target_img_description": "This describes the target image",
     "item_background_color": null,
     "item_text_color": null,
-    "initial_feedback": "This is the initial feedback.",
     "display_zone_borders": false,
     "display_zone_labels": false,
     "url_name": "test",

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -69,7 +69,6 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             "target_img_description": TARGET_IMG_DESCRIPTION,
             "item_background_color": None,
             "item_text_color": None,
-            "initial_feedback": START_FEEDBACK,
             "url_name": "",
         })
         self.assertEqual(zones, DEFAULT_DATA["zones"])


### PR DESCRIPTION
**Note:** ~~This PR is based on #87, only relevant commit is the last one.~~

**Description:** This PR allows DnDv2 to show item feedback messages in assessment mode.

**JIRA:** [SOL-1980](https://openedx.atlassian.net/browse/SOL-1980)

**Discussions:** [SOL-1980](https://openedx.atlassian.net/browse/SOL-1980)

**Dependencies:** ~~#87~~

**Sandboxes:**

* LMS: http://dndv2-sandbox8.opencraft.hosting/
* Studio: http://studio-dndv2-sandbox8.opencraft.hosting

**Testing instructions:**
1. Configure DnDv2 to have unique "incorrect" item feedback messages. Set to assessment mode.
2. In LMS, put some items into *wrong* zones.
3. Check answer (click "Submit")
4. Feedback popup should appear showing incorrect feedback messages for every misplaced item.
5. ~~If only one item is misplaced, only feedback message is shown; if multiple items are misplaced,~~ popup contains a note about ~~multiple~~ item(s) being misplaced, and feedback messages are shown in form of bullet list.

**Screenshots:**

<!-- Single misplaced: -->

<!-- ![image](https://cloud.githubusercontent.com/assets/3330048/17589848/9d65517a-5fdf-11e6-8120-bef441c65480.png) -->

<!-- Multiple misplaced: -->

![image](https://cloud.githubusercontent.com/assets/3330048/17589879/bf581ad8-5fdf-11e6-85b1-1cc734e444b3.png)

**Reviewers:**
- [x] internal: @itsjeyd 
- [x] internal: @haikuginger
- [x] TNL: @cahrens 
- [x] TNL: @staubina
- [ ] ~~a11y: @cptvitamin~~ a11y review will be performed later, for all changes in v2.1: [SOL-1978](https://openedx.atlassian.net/browse/SOL-1978)
- [x] Product: @sstack22

**Checklist:**
- [x] Internal review
- [x] Upstream review
- [x] Squash commits