### PR TITLE
Version bump: v2.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "sh install_test_deps.sh"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.7.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.8.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2 tests

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+Version 2.0.8 (2016-08-15)
+--------------------------
+
+* Numerical input feature removed
+* Multiple drop zones per item
+* Assessment mode - first version
+
+
+Version 2.0.7 (2016-06-10)
+--------------------------
+
+* Translation fix: removed duplicate entries in translation files
+
 Version 2.0.6 (2016-05-20)
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.7',
+    version='2.0.8',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
**Description:** This PR bumps drag-and-drop-v2 version to 2.0.8

**JIRA:** [SOL-1944](https://openedx.atlassian.net/browse/SOL-1944)

**Motivation:** Updating to v2.0.8 to include in the upcoming edx-platform release (Aug 15th, today)

**Reviewers:**
- [x] @bradenmacdonald 
- [x] @cahrens
- [x] @sstack22