### PR TITLE
Fix some flaky Selenium tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     sys.path.append(xblock_sdk_dir)
 
     # Use the workbench settings file:
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workbench.settings")
     # Configure a range of ports in case the default port of 8081 is in use
     os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS", "localhost:8081-8099")
 

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -3,6 +3,7 @@
 from xml.sax.saxutils import escape
 from selenium.webdriver.support.ui import WebDriverWait
 
+from bok_choy.promise import EmptyPromise
 from workbench import scenarios
 from xblockutils.resources import ResourceLoader
 
@@ -122,3 +123,14 @@ class BaseIntegrationTest(SeleniumBaseTest):
         wait = WebDriverWait(elem, 2)
         wait.until(lambda e: class_name in e.get_attribute('class').split(),
                    u"Class name {} not in {}".format(class_name, elem.get_attribute('class')))
+
+    def wait_for_ajax(self, timeout=15):
+        """
+        Wait for jQuery to be loaded and for all ajax requests to finish.
+        Same as bok-choy's PageObject.wait_for_ajax()
+        """
+        def is_ajax_finished():
+            """ Check if all the ajax calls on the current page have completed. """
+            return self.browser.execute_script("return typeof(jQuery)!='undefined' && jQuery.active==0")
+
+        EmptyPromise(is_ajax_finished, "Finished waiting for ajax requests.", timeout=timeout).fulfill()


### PR DESCRIPTION
This is an urgent PR to fix problematic selenium tests with this XBlock, when run on Travis CI.


* Any tests that used `AssessmentTestMixin.click_submit()` would virtually never pass, because it did not wait for the AJAX call to complete before continuing on to assert follow-up behavior
  * This is by far the biggest problem at the moment
* The whole Selenium test suite now supports both Firefox ( version < 47 ) and Chrome
  * Running tests in a different browser can help with debugging
  * Chrome runs tests locally much faster. To use Chrome locally, run:
      * `SELENIUM_BROWSER=chrome run_tests.py`
  * Running chrome on Travis CI requires the changes shown in 190eed9d4be414b4735b8c17613af0522677c309
* Replaces deprecated `settings` path with correct `workbench.settings` path (hides a warning)
* I included some other fixes for other flaky tests that I've seen; while these changes should not be regressions, I can't say for sure that they've fixed the issue.

I don't believe that this PR fixes *all* the flaky tests, but it should help.