### PR TITLE
Ensure old problems work on new version.

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -638,9 +638,8 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
     def _get_user_state(self):
         """ Get all user-specific data, and any applicable feedback """
         item_state = self._get_item_state()
-        # In assessment mode, if item is placed correctly and than the page is refreshed, "correct"
-        # will spill to the frontend, making item "disabled", thus allowing students to obtain answer by trial
-        # and error + refreshing the page. In order to avoid that, we remove "correct" from an item here
+        # In assessment mode, we do not want to leak the correctness info for individual items to the frontend,
+        # so we remove "correct" from all items when in assessment mode.
         if self.mode == self.ASSESSMENT_MODE:
             for item in item_state.values():
                 del item["correct"]
@@ -665,7 +664,7 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         """
 
         # IMPORTANT: this method should always return a COPY of self.item_state - it is called from get_user_state
-        # handler and manipulated there to hide correctness of items placed
+        # handler and the data it returns is manipulated there to hide correctness of items placed.
         state = {}
 
         for item_id, raw_item in self.item_state.iteritems():

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -638,25 +638,11 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
     def _get_user_state(self):
         """ Get all user-specific data, and any applicable feedback """
         item_state = self._get_item_state()
-        for item_id, item in item_state.iteritems():
-            # If information about zone is missing
-            # (because problem was completed before a11y enhancements were implemented),
-            # deduce zone in which item is placed from definition:
-            if item.get('zone') is None:
-                valid_zones = self._get_item_zones(int(item_id))
-                if valid_zones:
-                    # If we get to this point, then the item was placed prior to support for
-                    # multiple correct zones being added. As a result, it can only be correct
-                    # on a single zone, and so we can trust that the item was placed on the
-                    # zone with index 0.
-                    item['zone'] = valid_zones[0]
-                else:
-                    item['zone'] = 'unknown'
-
-            # In assessment mode, if item is placed correctly and than the page is refreshed, "correct"
-            # will spill to the frontend, making item "disabled", thus allowing students to obtain answer by trial
-            # and error + refreshing the page. In order to avoid that, we remove "correct" from an item here
-            if self.mode == self.ASSESSMENT_MODE:
+        # In assessment mode, if item is placed correctly and than the page is refreshed, "correct"
+        # will spill to the frontend, making item "disabled", thus allowing students to obtain answer by trial
+        # and error + refreshing the page. In order to avoid that, we remove "correct" from an item here
+        if self.mode == self.ASSESSMENT_MODE:
+            for item in item_state.values():
                 del item["correct"]
 
         overall_feedback_msgs, __ = self._get_feedback()
@@ -682,11 +668,32 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
         # handler and manipulated there to hide correctness of items placed
         state = {}
 
-        for item_id, item in self.item_state.iteritems():
-            if isinstance(item, dict):
-                state[item_id] = item.copy()  # items are manipulated in _get_user_state, so we protect actual data
+        for item_id, raw_item in self.item_state.iteritems():
+            if isinstance(raw_item, dict):
+                # Items are manipulated in _get_user_state, so we protect actual data.
+                item = copy.deepcopy(raw_item)
             else:
-                state[item_id] = {'top': item[0], 'left': item[1]}
+                item = {'top': raw_item[0], 'left': raw_item[1]}
+            # If information about zone is missing
+            # (because problem was completed before a11y enhancements were implemented),
+            # deduce zone in which item is placed from definition:
+            if item.get('zone') is None:
+                valid_zones = self._get_item_zones(int(item_id))
+                if valid_zones:
+                    # If we get to this point, then the item was placed prior to support for
+                    # multiple correct zones being added. As a result, it can only be correct
+                    # on a single zone, and so we can trust that the item was placed on the
+                    # zone with index 0.
+                    item['zone'] = valid_zones[0]
+                else:
+                    item['zone'] = 'unknown'
+            # If correctness information is missing
+            # (because problem was completed before assessment mode was implemented),
+            # assume the item is in correct zone (in standard mode, only items placed
+            # into correct zone are stored in item state).
+            if item.get('correct') is None:
+                item['correct'] = True
+            state[item_id] = item
 
         return state
 


### PR DESCRIPTION
## Description

Recent versions of the drag and drop v2 xblock require the `'correct'` field to be present in items stored in user state, but the `'correct'` field did not exist before assessment mode has been implemented and  problems created and completed before the introduction of assessment mode lack the `'correct'`  field.

Loading these stored items did not work on recent versions of DnDv2 xblock because recent versions are assuming the `'correct'` field is always present.

This patch adds the `'correct'` field to item state at load time. In standard mode, only items that are placed in correct zone are stored in item state, so we can assume that we can set the `'correct'` field to `True` for any item stored in the state that is missing the `'correct'` field.

## Dependencies

*None*

## JIRA

- [TNL-5308](https://openedx.atlassian.net/browse/TNL-5308)

## Sandbox URLs

I did not prepare a sandbox because verifying the changes involves (re)installing several versions of the DnDv2 xblock which cannot easily be done on a sandbox.
I can spin up a sandbox if you think it would still be useful, though.

## Testing Instructions

In order to test this, you need to create and complete (or partially complete) a DnDv2 problem using an older version of DnDv2 xblock. I used `v2.0.6`, but any pre-assessment mode version should work.

Assuming you have `xblock-drag-and-drop-v2` installed in editable mode (`pip install -e .`) in your devstack, follow these steps:

1. Check out version `v2.0.6` of DnD xblock in your devstack.
2. Restart the Studio and add a DnD problem to a unit. Default settings are fine.
3. Go to the LMS and complete (or partially complete) the problem.
4. Check out `edx-solutions/master` version of DnDv2 xblock.
5. Restart the LMS and try to load the DnD problem. The problem will fail to load. You will see a `KeyError` in the logs.
6. Checkout out `open-craft/mtyaka/legacy-item-state` branch.
7. Restart the LMS.
8. The problem should now load and work correctly.

## Reviewers

- [x] OpenCraft: @itsjeyd 
- [x] TNL: @staubina and/or @cahrens
- [ ] Product: @sstack22