### PR TITLE
Version bump: v2.0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "sh install_test_deps.sh"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.8.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.9.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,15 @@
+Version 2.0.9 (2016-09-01)
+--------------------------
+
+* ([#88](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/88)) Cleaned up studio editor template: styling, help texts, accessibility attributes, classes instead of IDs, etc.
+* ([#95](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/95)) Fixed flaky selenium tests
+* ([#85](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/85)) Accessibility improvements for item feedback popup
+* ([#73](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/73)) Accessibility improvements for item, zone and background image when using keyboard mode
+* ([#96](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/96)) Decoy items are properly accounted for in grade calculation and problem completion condition
+* ([#98](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/98)) Support for legacy item state
+* ([#92](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/92)) Prevented overlapping item placement: option to keep dropped item where learner dropped it was removed; items always use automatic layouts (left/center/right)
+* ([#93](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/93)) Per-item error feedback is shown in assessment mode when an attempt is submitted
+
 Version 2.0.8 (2016-08-15)
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.8',
+    version='2.0.9',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
**Description:** This PR bumps drag-and-drop-v2 version to 2.0.8

**JIRA:** [SOL-1803](https://openedx.atlassian.net/browse/SOL-1803)

**Motivation:** Updating to v2.0.9 to include in the upcoming edx-platform release (Sep 2nd)

**Merge deadline:** Sep 2nd.

**Reviewers:**
- [x] @smarnach 
- [x] @cahrens
- [ ] @sstack22