### PR TITLE
[SOL-1998] Implement Show Answer button

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ There are two problem modes available:
   attempt to place an item, and the number of attempts is not limited.
 * **Assessment**: In this mode, the learner places all items on the board and
   then clicks a "Submit" button to get feedback.  The number of attempts can be
-  limited.
+  limited.  When all attempts are used, the learner can click a "Show Answer"
+  button to temporarily place items on their correct drop zones.
 
 ![Drop zone edit](/doc/img/edit-view-zones.png)
 

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -549,7 +549,14 @@ class DragAndDropBlock(XBlock, XBlockWithSettingsMixin, ThemableXBlockMixin):
                 FeedbackMessages.correctly_placed,
                 FeedbackMessages.MessageClasses.CORRECTLY_PLACED
             )
-            _add_msg_if_exists(misplaced_ids, FeedbackMessages.misplaced, FeedbackMessages.MessageClasses.MISPLACED)
+
+            # Misplaced items are not returned to the bank on the final attempt.
+            if self.attempts_remain:
+                misplaced_template = FeedbackMessages.misplaced_returned
+            else:
+                misplaced_template = FeedbackMessages.misplaced
+
+            _add_msg_if_exists(misplaced_ids, misplaced_template, FeedbackMessages.MessageClasses.MISPLACED)
             _add_msg_if_exists(missing_ids, FeedbackMessages.not_placed, FeedbackMessages.MessageClasses.NOT_PLACED)
 
         if self.attempts_remain and (misplaced_ids or missing_ids):

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -502,6 +502,7 @@
         float: right;
         margin: 0;
         padding-right: -5px;
+        padding-top: 5px;
     }
 }
 
@@ -534,10 +535,6 @@
 
 .xblock--drag-and-drop .btn-icon {
     display: block;
-}
-
-.xblock--drag-and-drop .reset-button {
-    margin-top: 3px;
 }
 
 /*** ACTIONS TOOLBAR END ***/

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -545,7 +545,13 @@ msgid_plural "Correctly placed {correct_count} items."
 msgstr[0] ""
 msgstr[1] ""
 
-#: utils.py:32
+#: utils.py:62
+msgid "Misplaced {misplaced_count} item."
+msgid_plural "Misplaced {misplaced_count} items."
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:73
 msgid "Misplaced {misplaced_count} item. Misplaced item was returned to item bank."
 msgid_plural "Misplaced {misplaced_count} items. Misplaced items were returned to item bank."
 msgstr[0] ""

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -217,6 +217,14 @@ msgid "Max number of attempts reached"
 msgstr ""
 
 #: drag_and_drop_v2.py
+msgid "show_answer handler should only be called for assessment mode"
+msgstr ""
+
+#: drag_and_drop_v2.py
+msgid "There are attempts remaining"
+msgstr ""
+
+#: drag_and_drop_v2.py
 msgid "Unknown DnDv2 mode {mode} - course is misconfigured"
 msgstr ""
 
@@ -443,6 +451,14 @@ msgstr ""
 
 #: public/js/drag_and_drop.js
 msgid "Reset"
+msgstr ""
+
+#: public/js/drag_and_drop.js
+msgid "Show Answer"
+msgstr ""
+
+#: public/js/drag_and_drop.js
+msgid "Hide Answer"
 msgstr ""
 
 #: public/js/drag_and_drop.js

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -633,11 +633,17 @@ msgid_plural "Correctly placed {correct_count} items."
 msgstr[0] "Çörréçtlý pläçéd {correct_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 msgstr[1] "Çörréçtlý pläçéd {correct_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
 
-#: utils.py:32
-msgid "Misplaced {misplaced_count} item. Misplaced item was returned to item bank."
-msgid_plural "Misplaced {misplaced_count} items. Misplaced items were returned to item bank."
+#: utils.py:62
+msgid "Misplaced {misplaced_count} item."
+msgid_plural "Misplaced {misplaced_count} items."
 msgstr[0] "Mïspläçéd {misplaced_count} ïtém. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт,#"
 msgstr[1] "Mïspläçéd {misplaced_count} ïtéms. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, #"
+
+#: utils.py:73
+msgid "Misplaced {misplaced_count} item. Misplaced item was returned to item bank."
+msgid_plural "Misplaced {misplaced_count} items. Misplaced items were returned to item bank."
+msgstr[0] "Mïspläçéd {misplaced_count} ïtém. Mïspläçéd ïtém wäs rétürnéd tö ïtém ßänk. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+msgstr[1] "Mïspläçéd {misplaced_count} ïtéms. Mïspläçéd ïtéms wéré rétürnéd tö ïtém ßänk. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: utils.py:40
 msgid "Did not place {missing_count} required item."

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -272,6 +272,14 @@ msgid "Max number of attempts reached"
 msgstr "Mäx nümßér öf ättémpts réäçhéd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
 
 #: drag_and_drop_v2.py
+msgid "show_answer handler should only be called for assessment mode"
+msgstr "shöw_änswér händlér shöüld önlý ßé çälléd för ässéssmént mödé Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+
+#: drag_and_drop_v2.py
+msgid "There are attempts remaining"
+msgstr "Théré äré ättémpts rémäïnïng Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢#"
+
+#: drag_and_drop_v2.py
 msgid "Unknown DnDv2 mode {mode} - course is misconfigured"
 msgstr "Ûnknöwn DnDv2 mödé {mode} - çöürsé ïs mïsçönfïgüréd Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
@@ -518,6 +526,14 @@ msgstr "Çörréçtlý pläçéd ïn: {zone_title} Ⱡ'σяєм ιρѕυм ∂σ
 #: public/js/drag_and_drop.js
 msgid "Reset"
 msgstr "Rését Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
+
+#: public/js/drag_and_drop.js
+msgid "Show Answer"
+msgstr "Shöw Ànswér Ⱡ'σяєм ιρѕυм ∂σłσя #"
+
+#: public/js/drag_and_drop.js
+msgid "Hide Answer"
+msgstr "Hïdé Ànswér Ⱡ'σяєм ιρѕυм ∂σłσя #"
 
 #: public/js/drag_and_drop.js
 msgid "Submit"

--- a/drag_and_drop_v2/utils.py
+++ b/drag_and_drop_v2/utils.py
@@ -60,6 +60,17 @@ class FeedbackMessages(object):
         Formats "misplaced items" message
         """
         return ngettext(
+            'Misplaced {misplaced_count} item.',
+            'Misplaced {misplaced_count} items.',
+            number
+        ).format(misplaced_count=number)
+
+    @staticmethod
+    def misplaced_returned(number, ngettext=ngettext_fallback):
+        """
+        Formats "misplaced items returned to bank" message
+        """
+        return ngettext(
             'Misplaced {misplaced_count} item. Misplaced item was returned to item bank.',
             'Misplaced {misplaced_count} items. Misplaced items were returned to item bank.',
             number

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -126,6 +126,9 @@ class BaseIntegrationTest(SeleniumBaseTest):
     def _get_reset_button(self):
         return self._page.find_element_by_css_selector('.reset-button')
 
+    def _get_show_answer_button(self):
+        return self._page.find_element_by_css_selector('.show-answer-button')
+
     def _get_submit_button(self):
         return self._page.find_element_by_css_selector('.submit-answer-button')
 
@@ -392,12 +395,21 @@ class InteractionTestBase(object):
             self.assertDraggable(item_value)
             self.assertEqual(item.get_attribute('class'), 'option')
             self.assertEqual(item.get_attribute('tabindex'), '0')
-            self.assertEqual(item_description.text, 'Placed in: {}'.format(zone_title))
+            description = 'Placed in: {}'
         else:
             self.assertNotDraggable(item_value)
             self.assertEqual(item.get_attribute('class'), 'option fade')
             self.assertIsNone(item.get_attribute('tabindex'))
-            self.assertEqual(item_description.text, 'Correctly placed in: {}'.format(zone_title))
+            description = 'Correctly placed in: {}'
+
+        # An item with multiple drop zones could be located in any one of these
+        # zones. In that case, zone_title will be a list, and we need to check
+        # whether the zone info in the description of the item matches any of
+        # the zones in that list.
+        if isinstance(zone_title, list):
+            self.assertIn(item_description.text, [description.format(title) for title in zone_title])
+        else:
+            self.assertEqual(item_description.text, description.format(zone_title))
 
     def assert_reverted_item(self, item_value):
         item = self._get_item_by_value(item_value)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -5,7 +5,8 @@ from selenium.webdriver.common.keys import Keys
 from workbench.runtime import WorkbenchRuntime
 
 from drag_and_drop_v2.default_data import (
-    TOP_ZONE_TITLE, TOP_ZONE_ID, MIDDLE_ZONE_TITLE, MIDDLE_ZONE_ID, ITEM_CORRECT_FEEDBACK, ITEM_INCORRECT_FEEDBACK,
+    TOP_ZONE_TITLE, TOP_ZONE_ID, MIDDLE_ZONE_TITLE, MIDDLE_ZONE_ID, BOTTOM_ZONE_ID,
+    ITEM_CORRECT_FEEDBACK, ITEM_INCORRECT_FEEDBACK,
     ITEM_TOP_ZONE_NAME, ITEM_MIDDLE_ZONE_NAME,
 )
 from tests.integration.test_base import BaseIntegrationTest, DefaultDataTestMixin, InteractionTestBase, ItemDefinition
@@ -145,6 +146,20 @@ class AssessmentEventsFiredTest(
             dummy, name, published_data = self.publish.call_args_list[index][0]
             self.assertEqual(name, event['name'])
             self.assertEqual(published_data, event['data'])
+
+    def test_grade(self):
+        """
+        Test grading after submitting solution in assessment mode
+        """
+        self.place_item(0, TOP_ZONE_ID, Keys.RETURN)  # Correctly placed item
+        self.place_item(1, BOTTOM_ZONE_ID, Keys.RETURN)  # Incorrectly placed item
+        self.place_item(4, MIDDLE_ZONE_ID, Keys.RETURN)  # Incorrectly placed decoy
+        self.click_submit()
+
+        events = self.publish.call_args_list
+        published_grade = next((event[0][2] for event in events if event[0][1] == 'grade'))
+        expected_grade = {'max_value': 1, 'value': (1.0 / 5.0)}
+        self.assertEqual(published_grade, expected_grade)
 
 
 @ddt

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -442,7 +442,7 @@ class MultipleBlocksDataInteraction(ParameterizedTestsMixin, InteractionTestBase
 
         self._switch_to_block(1)
         # Test mouse and keyboard interaction
-        self.interact_with_keyboard_help(scroll_down=900)
+        self.interact_with_keyboard_help(scroll_down=1200)
         self.interact_with_keyboard_help(scroll_down=0, use_keyboard=True)
 
 

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -9,7 +9,6 @@ import time
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
-from workbench.runtime import WorkbenchRuntime
 from xblockutils.resources import ResourceLoader
 
 from drag_and_drop_v2.default_data import (
@@ -260,26 +259,6 @@ class AssessmentInteractionTest(
         ]
         expected_feedback = "\n".join(feedback_lines)
         self.assertEqual(self._get_feedback().text, expected_feedback)
-
-    def test_grade(self):
-        """
-        Test grading after submitting solution in assessment mode
-        """
-        mock = Mock()
-        context = patch.object(WorkbenchRuntime, 'publish', mock)
-        context.start()
-        self.addCleanup(context.stop)
-        self.publish = mock
-
-        self.place_item(0, TOP_ZONE_ID, Keys.RETURN)  # Correctly placed item
-        self.place_item(1, BOTTOM_ZONE_ID, Keys.RETURN)  # Incorrectly placed item
-        self.place_item(4, MIDDLE_ZONE_ID, Keys.RETURN)  # Incorrectly placed decoy
-        self.click_submit()
-
-        events = self.publish.call_args_list
-        published_grade = next((event[0][2] for event in events if event[0][1] == 'grade'))
-        expected_grade = {'max_value': 1, 'value': (1.0 / 5.0)}
-        self.assertEqual(published_grade, expected_grade)
 
     def test_per_item_feedback_multiple_misplaced(self):
         self.place_item(0, MIDDLE_ZONE_ID, Keys.RETURN)

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -236,7 +236,7 @@ class AssessmentInteractionTest(
         feedback_lines = [
             "FEEDBACK",
             FeedbackMessages.correctly_placed(1),
-            FeedbackMessages.misplaced(1),
+            FeedbackMessages.misplaced_returned(1),
             FeedbackMessages.not_placed(2),
             START_FEEDBACK
         ]

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -553,12 +553,19 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
             self._make_feedback_message(
                 FeedbackMessages.correctly_placed(1), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
             ),
-            self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED),
+            self._make_feedback_message(FeedbackMessages.misplaced_returned(1), FeedbackMessages.MessageClasses.MISPLACED),
             self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
             self._make_feedback_message(self.INITIAL_FEEDBACK, None),
         ]
 
         self._assert_item_and_overall_feedback(res, expected_item_feedback, expected_overall_feedback)
+
+    def test_do_attempt_shows_correct_misplaced_feedback_at_last_attempt(self):
+        self._set_final_attempt()
+        self._submit_solution({0: self.ZONE_2})
+        res = self._do_attempt()
+        misplaced_message = self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED)
+        self.assertIn(misplaced_message, res[self.OVERALL_FEEDBACK_KEY])
 
     def test_do_attempt_no_item_state(self):
         """
@@ -584,7 +591,7 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
             self._make_feedback_message(
                 FeedbackMessages.correctly_placed(2), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
             ),
-            self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED),
+            self._make_feedback_message(FeedbackMessages.misplaced_returned(1), FeedbackMessages.MessageClasses.MISPLACED),
             self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
             self._make_feedback_message(self.INITIAL_FEEDBACK, None),
         ]

--- a/tests/unit/test_advanced.py
+++ b/tests/unit/test_advanced.py
@@ -551,11 +551,21 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
         expected_item_feedback = [self._make_feedback_message(self.FEEDBACK[0]['incorrect'])]
         expected_overall_feedback = [
             self._make_feedback_message(
-                FeedbackMessages.correctly_placed(1), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+                FeedbackMessages.correctly_placed(1),
+                FeedbackMessages.MessageClasses.CORRECTLY_PLACED
             ),
-            self._make_feedback_message(FeedbackMessages.misplaced_returned(1), FeedbackMessages.MessageClasses.MISPLACED),
-            self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
-            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+            self._make_feedback_message(
+                FeedbackMessages.misplaced_returned(1),
+                FeedbackMessages.MessageClasses.MISPLACED
+            ),
+            self._make_feedback_message(
+                FeedbackMessages.not_placed(1),
+                FeedbackMessages.MessageClasses.NOT_PLACED
+            ),
+            self._make_feedback_message(
+                self.INITIAL_FEEDBACK,
+                None
+            ),
         ]
 
         self._assert_item_and_overall_feedback(res, expected_item_feedback, expected_overall_feedback)
@@ -564,7 +574,10 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
         self._set_final_attempt()
         self._submit_solution({0: self.ZONE_2})
         res = self._do_attempt()
-        misplaced_message = self._make_feedback_message(FeedbackMessages.misplaced(1), FeedbackMessages.MessageClasses.MISPLACED)
+        misplaced_message = self._make_feedback_message(
+            FeedbackMessages.misplaced(1),
+            FeedbackMessages.MessageClasses.MISPLACED
+        )
         self.assertIn(misplaced_message, res[self.OVERALL_FEEDBACK_KEY])
 
     def test_do_attempt_no_item_state(self):
@@ -589,11 +602,21 @@ class TestDragAndDropAssessmentData(AssessmentModeFixture, unittest.TestCase):
         expected_item_feedback = []
         expected_overall_feedback = [
             self._make_feedback_message(
-                FeedbackMessages.correctly_placed(2), FeedbackMessages.MessageClasses.CORRECTLY_PLACED
+                FeedbackMessages.correctly_placed(2),
+                FeedbackMessages.MessageClasses.CORRECTLY_PLACED
             ),
-            self._make_feedback_message(FeedbackMessages.misplaced_returned(1), FeedbackMessages.MessageClasses.MISPLACED),
-            self._make_feedback_message(FeedbackMessages.not_placed(1), FeedbackMessages.MessageClasses.NOT_PLACED),
-            self._make_feedback_message(self.INITIAL_FEEDBACK, None),
+            self._make_feedback_message(
+                FeedbackMessages.misplaced_returned(1),
+                FeedbackMessages.MessageClasses.MISPLACED
+            ),
+            self._make_feedback_message(
+                FeedbackMessages.not_placed(1),
+                FeedbackMessages.MessageClasses.NOT_PLACED
+            ),
+            self._make_feedback_message(
+                self.INITIAL_FEEDBACK,
+                None
+            ),
         ]
 
         self._assert_item_and_overall_feedback(res, expected_item_feedback, expected_overall_feedback)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,6 +47,7 @@ class TestCaseMixin(object):
     DROP_ITEM_HANDLER = 'drop_item'
     DO_ATTEMPT_HANDLER = 'do_attempt'
     RESET_HANDLER = 'reset'
+    SHOW_ANSWER_HANDLER = 'show_answer'
     USER_STATE_HANDLER = 'get_user_state'
 
     def patch_workbench(self):


### PR DESCRIPTION
## Description

In assessment mode, when the learner has run out of attempts, enable a "Show Answer" button. Clicking it causes all items to move to a correct placement.

## Author

@arbrandes

OpenCraft review via https://github.com/open-craft/xblock-drag-and-drop-v2/pull/10.

## Dependencies

*None*

## JIRA

- [SOL-1998](https://openedx.atlassian.net/browse/SOL-1998)

## Sandbox URLs

- [Assessment mode](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/): a DnDv2 instance in assessment mode, with one maximum attempt.
- [Standard mode](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2_standard/): a DnDv2 instance in standard mode.

## Latest commit

- https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/101/commits/4c6fb7d74c35ef46bf4cd821d0a52320e0df7d90 *(updated 2016-09-21)*

## Testing instructions

### Assessment mode

1. Go to the [assessment mode DnDv2 instance](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/) on the LMS, and log in as `staff@example.com`.
2. Click on `Staff Debug Info`, `Delete Student State`, and refresh the page.
3. Notice that there is a "Show Answer" button, because this is in assessment mode.
4. Notice that the "Show Answer" button is disabled, because this is your first attempt.  
5. Pick any item and drop it onto any zone.
6. Click submit, which will make you run out of attempts (there's only one).
7. Notice that the "Show Answer" button is now enabled.
8. Click the "Show Answer" button. Observe that:
   * All items are placed correctly
   * Decoy items are still in the bank.
   * You can't drag any of the items.
   * The "Show Answer" button is disabled.
9. Refresh the page, and see that your final attempt is displayed. **Note**: This currently only works if you did not misplace any items; a decoy item that was placed on the board counts as a misplaced item. See "Notes" below for more info.
10. Click "Show Answer" again. The same thing should happen again.

### Standard mode

1. Go to the [standard mode DnDv2 instance](http://dndv2-sol-1998.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2_standard/) on the LMS, and log in as `staff@example.com`.
2. Notice that there is no "Show Answer" button, because this is in standard mode.

## Notes

There is an existing issue (present on master) that causes misplaced items to return to the item bank when refreshing the page after submitting the last remaining attempt for a DnDv2 problem. This PR does not include a fix for this issue. As a result, refreshing the page as described in step 9 above only produces expected results if items that were placed on the board in the final attempt are located in correct zones.

## Reviewers

- [x] OpenCraft: @itsjeyd
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: To be completed as part of [SOL-1978](https://openedx.atlassian.net/browse/SOL-1978)
- [x] Product: @sstack22

Also tagging @pdesjardins as a docs FYI.