### PR TITLE
RTL fixes

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -307,32 +307,68 @@
 
 
 /* Font Awesome icons have different width - margin-right tries to compensate it */
-.xblock--drag-and-drop .feedback p:before {
+.ltr .xblock--drag-and-drop .feedback p:before,
+.rtl .xblock--drag-and-drop .feedback p:after {
     content: "\f129";
     font-family: FontAwesome;
+}
+
+.ltr .xblock--drag-and-drop .feedback p:before {
     margin-right: 0.7em;
     margin-left: 0.3em;
 }
 
-.xblock--drag-and-drop .feedback p.correct:before {
+.rtl .xblock--drag-and-drop .feedback p:after {
+    margin-left: 0.7em;
+    margin-right: 0.3em;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.correct:before,
+.rtl .xblock--drag-and-drop .feedback p.correct:after {
     content: "\f00c";
     font-family: FontAwesome;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.correct:before {
     margin-right: 0.3em;
     margin-left: 0;
 }
 
-.xblock--drag-and-drop .feedback p.partial:before {
+.rtl .xblock--drag-and-drop .feedback p.correct:after {
+    margin-left: 0.3em;
+    margin-right: 0;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.partial:before,
+.rtl .xblock--drag-and-drop .feedback p.partial:after {
     content: "\f069";
     font-family: FontAwesome;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.partial:before {
     margin-right: 0.3em;
     margin-left: 0;
 }
 
-.xblock--drag-and-drop .feedback p.incorrect:before {
+.rtl .xblock--drag-and-drop .feedback p.partial:after {
+    margin-left: 0.3em;
+    margin-right: 0;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.incorrect:before,
+.rtl .xblock--drag-and-drop .feedback p.incorrect:after {
     content: "\f00d";
     font-family: FontAwesome;
+}
+
+.ltr .xblock--drag-and-drop .feedback p.incorrect:before {
     margin-right: 0.45em;
     margin-left: 0.1em;
+}
+
+.rtl .xblock--drag-and-drop .feedback p.incorrect:after {
+    margin-left: 0.45em;
+    margin-right: 0.1em;
 }
 
 .xblock--drag-and-drop .popup {
@@ -362,13 +398,22 @@
 
 .xblock--drag-and-drop .popup .close-feedback-popup-button {
     cursor: pointer;
-    float: right;
-    margin-right: 8px;
     margin-top: 8px;
-    margin-left: 20px;
     color: #ffffff;
     font-family: "fontawesome";
     font-size: 18pt;
+}
+
+.ltr .xblock--drag-and-drop .popup .close-feedback-popup-button {
+    float: right;
+    margin-right: 8px;
+    margin-left: 20px;
+}
+
+.rtl .xblock--drag-and-drop .popup .close-feedback-popup-button {
+    float: left;
+    margin-right: 20px;
+    margin-left: 8px;
 }
 
 .xblock--drag-and-drop .popup .close-feedback-popup-button:focus {
@@ -487,39 +532,77 @@
 }
 
 .xblock--drag-and-drop .attempts-used {
-    margin-left: 0.675em;
     font-size: 0.875em;
     color: #666;
 }
 
+.ltr .xblock--drag-and-drop .attempts-used {
+    margin-left: 0.675em;
+}
+
+.rtl .xblock--drag-and-drop .attempts-used {
+    margin-right: 0.675em;
+}
+
 .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
-    text-align: left;
     display: block;
+}
+
+.ltr .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+    text-align: left;
+}
+
+.rtl .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+    text-align: right;
 }
 
 @media (min-width: 768px) {
     .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
-        float: right;
         margin: 0;
+    }
+
+    .ltr .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+        float: right;
         padding-right: -5px;
+    }
+
+    .rtl .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+        float: left;
+        padding-left: -5px;
     }
 }
 
 .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
-    border-right: 1px solid #ddd;
     border-collapse: collapse;
     padding: 0 5px;
     display: inline-block;
     height: 100%;
 }
 
-.xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:first-child {
+.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
+    border-right: 1px solid #ddd;
+}
+
+.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
+    border-left: 1px solid #ddd;
+}
+
+.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:first-child {
     padding-left: 0;
 }
 
-.xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:last-child {
+.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:first-child {
+    padding-right: 0;
+}
+
+.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:last-child {
     border-right: none;
     padding-right: 0;
+}
+
+.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:last-child {
+    border-left: none;
+    padding-left: 0;
 }
 
 .xblock--drag-and-drop .sidebar-buttons .btn-brand {


### PR DESCRIPTION
## Description

Introduce proper right-to-left support for the following:

* Alignment of overall feedback message icons and text
* Alignment and borders of sidebar buttons
* Margin of the "You have used X attempts" message

## Dependencies

*None*

## JIRA

- [SOL-2031](https://openedx.atlassian.net/browse/SOL-2031)

## Sandbox URLs

- [LMS](http://dndv2-pr96.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/)
- [Studio](http://studio-dndv2-pr96.opencraft.hosting/container/block-v1:test+tt101+run+type@vertical+block@drag_and_drop_v2)

## Latest commit

- fe49f58 *(updated 2016-09-14)*

## Testing instructions

1. Go to the pre-deployed assessment-mode block on the [LMS](http://dndv2-pr96.opencraft.hosting/courses/course-v1:test+tt101+run/courseware/chapter/drag_and_drop_v2/), and log in as `staff@example.com`.
2. Click on `Staff Debug Info`, and `Delete Student State` for the `staff@example.com` user.  Close the modal.
3. Pick a regular item and place it correctly in its zone.  Click submit, and notice that there are now 3 overall feedback messages, all of them correctly aligned.
4. [Update the language](http://dndv2-pr96.opencraft.hosting/update_lang/) to `ar`.
5. Go back to the block and refresh the page.
6. Notice that in Arabic, the feedback message icons are properly aligned on the right.
7. Notice that the sidebar buttons (reset and keyboard help) are properly aligned on the left.
8. Notice that the "You have used X attempts" message is properly spaced away from the submit button.

## Screenshots

![oc1859-1](https://cloud.githubusercontent.com/assets/759355/18232738/f23ded26-72ac-11e6-85d3-810cdd99b920.png)

## Reviewers

- [x] OpenCraft: @pomegranited
- [ ] TNL: @cahrens or @staubina
- [ ] a11y: @cptvitamin or @clrux - did you want to have a look at this too?
- [ ] Product: @marcotuts (CC @sstack22)