### PR TITLE
Enforcing XBlock variable types

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -63,6 +63,7 @@ class DragAndDropBlock(
         help=_("The title of the drag and drop problem. The title is displayed to learners."),
         scope=Scope.settings,
         default=_("Drag and Drop"),
+        enforce_type=True,
     )
 
     mode = String(
@@ -78,7 +79,8 @@ class DragAndDropBlock(
             {"display_name": _("Standard"), "value": Constants.STANDARD_MODE},
             {"display_name": _("Assessment"), "value": Constants.ASSESSMENT_MODE},
         ],
-        default=Constants.STANDARD_MODE
+        default=Constants.STANDARD_MODE,
+        enforce_type=True,
     )
 
     max_attempts = Integer(
@@ -89,6 +91,7 @@ class DragAndDropBlock(
         ),
         scope=Scope.settings,
         default=None,
+        enforce_type=True,
     )
 
     show_title = Boolean(
@@ -96,6 +99,7 @@ class DragAndDropBlock(
         help=_("Display the title to the learner?"),
         scope=Scope.settings,
         default=True,
+        enforce_type=True,
     )
 
     question_text = String(
@@ -103,6 +107,7 @@ class DragAndDropBlock(
         help=_("The description of the problem or instructions shown to the learner."),
         scope=Scope.settings,
         default="",
+        enforce_type=True,
     )
 
     show_question_header = Boolean(
@@ -110,6 +115,7 @@ class DragAndDropBlock(
         help=_('Display the heading "Problem" above the problem text?'),
         scope=Scope.settings,
         default=True,
+        enforce_type=True,
     )
 
     weight = Float(
@@ -117,6 +123,7 @@ class DragAndDropBlock(
         help=_("Defines the number of points the problem is worth."),
         scope=Scope.settings,
         default=1,
+        enforce_type=True,
     )
 
     item_background_color = String(
@@ -124,6 +131,7 @@ class DragAndDropBlock(
         help=_("The background color of draggable items in the problem (example: 'blue' or '#0000ff')."),
         scope=Scope.settings,
         default="",
+        enforce_type=True,
     )
 
     item_text_color = String(
@@ -131,13 +139,15 @@ class DragAndDropBlock(
         help=_("Text color to use for draggable items (example: 'white' or '#ffffff')."),
         scope=Scope.settings,
         default="",
+        enforce_type=True,
     )
 
     max_items_per_zone = Integer(
         display_name=_("Maximum items per zone"),
         help=_("This setting limits the number of items that can be dropped into a single zone."),
         scope=Scope.settings,
-        default=None
+        default=None,
+        enforce_type=True,
     )
 
     data = Dict(
@@ -149,24 +159,28 @@ class DragAndDropBlock(
         ),
         scope=Scope.content,
         default=DEFAULT_DATA,
+        enforce_type=True,
     )
 
     item_state = Dict(
         help=_("Information about current positions of items that a learner has dropped on the target image."),
         scope=Scope.user_state,
         default={},
+        enforce_type=True,
     )
 
     attempts = Integer(
         help=_("Number of attempts learner used"),
         scope=Scope.user_state,
-        default=0
+        default=0,
+        enforce_type=True,
     )
 
     completed = Boolean(
         help=_("Indicates whether a learner has completed the problem at least once"),
         scope=Scope.user_state,
         default=False,
+        enforce_type=True,
     )
 
     grade = Float(
@@ -178,7 +192,8 @@ class DragAndDropBlock(
     raw_earned = Float(
         help=_("Keeps maximum score achieved by student as a raw value between 0 and 1."),
         scope=Scope.user_state,
-        default=0
+        default=0,
+        enforce_type=True,
     )
 
     block_settings_key = 'drag-and-drop-v2'

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,7 @@ reports=no
 
 [FORMAT]
 max-line-length=120
+max-module-lines=1500
 
 [MESSAGES CONTROL]
 disable=

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -236,6 +236,17 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
 
         self.assertIsNone(self.block.max_items_per_zone)
 
+    def test_studio_submit_coerce_to_integer(self):
+        # Validate that numbers submitted as strings are being
+        # coerced to integers rather than being saved as strings
+        def modify_submission(submission):
+            submission['max_attempts'] = '1234567890'
+
+        body = self._make_submission(modify_submission)
+        self.call_handler('studio_submit', body)
+        self.assertEqual(self.block.max_attempts, 1234567890)
+        self.assertEqual(type(self.block.max_attempts), int)
+
     def test_expand_static_url(self):
         """ Test the expand_static_url handler needed in Studio when changing the image """
         res = self.call_handler('expand_static_url', '/static/blah.png')


### PR DESCRIPTION
We encountered an issue where excessively long numbers submitted through the configuration pane would be saved as strings in Mongo, and would prevent the XBlock from loading correctly in Studio, because in integer form, they were too large to store. This change will cast all entries to the appropriate type, allowing the Mongo database driver to raise appropriate exceptions, rather than save incorrect values to the database.

**JIRA issue**:  [SOL-2088](https://openedx.atlassian.net/browse/SOL-2088)

**Testing Instructions**
1. With the existing version of the xblock, create a block in a course.
2. With the existing version of the xblock, edit the block.
3. With the existing version of the xblock, submit a large number (e.g., 99999999999999999999999) for the `max_attempts` field after setting `mode` to Assessment.
4. Note that the value is accepted, but thereafter, the block cannot be loaded.
5. Delete the block
6. Install this version of the xblock.
7. Run Studio; note that because recent versions of OpenEdX require Drag and Drop V2, you must do `paver devstack studio --fast` to avoid having this version of the XBlock overwritten with the current release version.
8. Again, create a block in a course.
9. Again, edit the block.
10. Again, submit the same large number for the `max_attempts` field after setting`mode` to Assessment.
11. Note that the value is rejected.
12. Note that the block can still be loaded, without the value that was submitted.

**Notes**

What we're looking for is basically for the XBlock API to coerce any values for integer fields to integers. This ensures that the Mongo database driver's type checking can properly validate all numbers, including large numbers, prior to them being inserted into the database.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD
