### PR TITLE
[SOL-2077] Prevent 'Change Background' button from forcing form submission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "sh install_test_deps.sh"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.9.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.10.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Version 2.0.10 (2016-09-22)
+---------------------------
+
+* ([#97](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/97)) Added "item" field to item.dropped event
+* ([#101](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/101)) Implement "show answer" button
+* ([#103](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/103)) Miscellaneous UI fixes
+* ([#105](https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/105)) Correct an issue with background image selection
+
 Version 2.0.9 (2016-09-01)
 --------------------------
 

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -97,7 +97,7 @@
                            type="text"
                            aria-describedby="background-url-{{id_suffix}}" />
                     </label>
-                    <button class="btn">{% trans "Change background" %}</button>
+                    <button type="button" class="btn">{% trans "Change background" %}</button>
                     <div id="background-url-description-{{id_suffix}}" class="form-help">
                         {% trans "For example, 'http://example.com/background.png' or '/static/background.png'." %}
                     </div>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.9',
+    version='2.0.10',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
As part of #88, we inadvertently removed a `PreventDefaults` call from the event handler for the "Change Background" button. Since some browsers default the type of `<button>` elements to `submit`, this resulted in the form being submitted synchronously, resulting in a page reload, and preventing the updated image URI from being saved. This change explicitly sets that button's type to "button", which has no default submission behavior.

**JIRA tickets**: Fixes SOL-2077

**Testing instructions**:

1. In a devstack running the master version of DnDv2, create a problem.
2. Attempt to set the background image of that problem to a different URL; set the value, and click the "Change Background" button.
3. Observe that the form is immediately submitted and the page refreshed.
4. Observe that your new image is not used.
5. Install this branch.
6. Again attempt to set the background image; set the value, click the "Change Background" button, click the "Continue" button, and click "Save".
7. Observe that the configuration dialog is not closed when you click "Change Background".
8. Observe that after clicking Save, your image choice is used for the DnDv2 problem.

**Reviewers**
- [ ] @pomegranited
- [ ] TNL: @cahrens and/or @staubina
- [ ] a11y: @edx/edx-accessibility
- [ ] Product: @sstack22