### PR TITLE
Display grade information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_install:
     - "sh -e /etc/init.d/xvfb start"
 install:
     - "sh install_test_deps.sh"
+    # Remove the next two lines after our test suite is compatible with selenium 3.
+    - "pip uninstall -y selenium"
+    - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
     - "pip install dist/xblock-drag-and-drop-v2-2.0.11.tar.gz"

--- a/README.md
+++ b/README.md
@@ -500,13 +500,13 @@ This command scrapes all the strings in all `*.py` files in `drag_and_drop_v2` f
  in `drag_and_drop_v2` folder:
 
 ```
-~/xblock-drag-and-drop-v2/drag_and_drop_v2$ find . -name "*.py" | xargs xgettext --language=python
+~/xblock-drag-and-drop-v2/drag_and_drop_v2$ find . -name "*.py" | xargs xgettext --language=python --add-comments="Translators:"
 ```
 
 Javascript command is a little bit more verbose:
 
 ```
-~/xblock-drag-and-drop-v2/drag_and_drop_v2$ find . -name "*.js" -o  -path ./public/js/vendor -prune -a -type f | xargs xgettext --language=javascript --from-code=utf-8
+~/xblock-drag-and-drop-v2/drag_and_drop_v2$ find . -name "*.js" -o  -path ./public/js/vendor -prune -a -type f | xargs xgettext --language=javascript --from-code=utf-8 --add-comments="Translators:"
 ```
 
 Note that both commands generate partial `messages.po` file - JS or python only, while `test.po` is supposed to contain

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -39,9 +39,10 @@
 
 /* Header, instruction text, etc. */
 
-.xblock--drag-and-drop .problem-title {
+.xblock--drag-and-drop .problem-progress {
     display: inline-block;
-    margin: 0 0 15px 0;
+    color: #5e5e5e;
+    font-size: 0.875em;
 }
 
 .xblock--drag-and-drop .problem p {

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -51,6 +51,9 @@
                         <span>{% trans fields.weight.display_name %}</span>
                         <input class="weight" type="number" step="0.1" value="{{ self.weight|unlocalize }}" />
                     </label>
+                    <div id="weight-description-{{id_suffix}}" class="assessment-setting form-help">
+                      {% trans fields.weight.help %}
+                    </div>
 
                     <label class="h4">
                         <span>{% trans fields.question_text.display_name %}</span>

--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -160,11 +160,11 @@ msgid "Display the heading \"Problem\" above the problem text?"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "Maximum score"
+msgid "Problem Weight"
 msgstr ""
 
 #: drag_and_drop_v2.py
-msgid "The maximum score the learner can receive for the problem."
+msgid "Defines the number of points the problem is worth."
 msgstr ""
 
 #: drag_and_drop_v2.py
@@ -535,7 +535,40 @@ msgstr ""
 msgid "Close item feedback popup"
 msgstr ""
 
-#: utils.py:18
+
+# Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
+#: public/js/drag_and_drop.js:453
+msgid "{earned}/{possible} point (graded)"
+msgid_plural "{earned}/{possible} points (graded)"
+msgstr[0] ""
+msgstr[1] ""
+
+# Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
+#: public/js/drag_and_drop.js:459
+msgid "{earned}/{possible} point (ungraded)"
+msgid_plural "{earned}/{possible} points (ungraded)"
+msgstr[0] ""
+msgstr[1] ""
+
+# Translators: {possible} is the number of points possible (examples: 1, 3, 10).
+#: public/js/drag_and_drop.js:468
+msgid "{possible} point possible (graded)"
+msgid_plural "{possible} points possible (graded)"
+msgstr[0] ""
+msgstr[1] ""
+
+# Translators: {possible} is the number of points possible (examples: 1, 3, 10).
+#: public/js/drag_and_drop.js:474
+msgid "{possible} point possible (ungraded)"
+msgid_plural "{possible} points possible (ungraded)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: utils.py:44
+msgid "Your highest score is {score}"
+msgstr ""
+
+#: utils.py:45
 msgid "Final attempt was used, highest score is {score}"
 msgstr ""
 

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -197,14 +197,12 @@ msgstr ""
 "ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: drag_and_drop_v2.py
-msgid "Maximum score"
-msgstr "Mäxïmüm sçöré Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
+msgid "Problem Weight"
+msgstr "Prößlém Wéιght Ⱡ'σяєм ιρѕυм ∂σłσя ѕι#"
 
 #: drag_and_drop_v2.py
-msgid "The maximum score the learner can receive for the problem."
-msgstr ""
-"Thé mäxïmüm sçöré thé léärnér çän réçéïvé för thé prößlém Ⱡ'σяєм ιρѕυм ∂σłσя"
-" ѕιт αмєт, ¢σηѕє¢тєтυя α#"
+msgid "Defines the number of points the problem is worth."
+msgstr "Défïnés thé nümßér öf pöïnts thé prößlém ïs wörth. Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: drag_and_drop_v2.py
 msgid "Item background color"
@@ -619,11 +617,39 @@ msgstr ""
 msgid "None"
 msgstr "Nöné Ⱡ'σяєм ι#"
 
+#: public/js/drag_and_drop.js:453
+msgid "{earned}/{possible} point (graded)"
+msgid_plural "{earned}/{possible} points (graded)"
+msgstr[0] "{earned}/{possible} pöïnt (grädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
+msgstr[1] "{earned}/{possible} pöïnts (grädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢#"
+
+#: public/js/drag_and_drop.js:459
+msgid "{earned}/{possible} point (ungraded)"
+msgid_plural "{earned}/{possible} points (ungraded)"
+msgstr[0] "{earned}/{possible} pöïnt (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢ση#"
+msgstr[1] "{earned}/{possible} pöïnts (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢ση#"
+
+#: public/js/drag_and_drop.js:468
+msgid "{possible} point possible (graded)"
+msgid_plural "{possible} points possible (graded)"
+msgstr[0] "{possible} pöïnt pössïßlé (grädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
+msgstr[1] "{possible} pöïnts pössïßlé (grädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє#"
+
+#: public/js/drag_and_drop.js:474
+msgid "{possible} point possible (ungraded)"
+msgid_plural "{possible} points possible (ungraded)"
+msgstr[0] "{possible} pöïnt pössïßlé (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+msgstr[1] "{possible} pöïnts pössïßlé (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
+
 #: public/js/drag_and_drop_edit.js
 msgid "Close item feedback popup"
 msgstr "Çlösé ïtém féédßäçk pöpüp Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
 
-#: utils.py:18
+#: utils.py:44
+msgid "Your highest score is {score}"
+msgstr "Ýöür hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕ#"
+
+#: utils.py:45
 msgid "Final attempt was used, highest score is {score}"
 msgstr "Fïnäl ättémpt wäs üséd, hïghést sçöré ïs {score} Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя #"
 

--- a/drag_and_drop_v2/utils.py
+++ b/drag_and_drop_v2/utils.py
@@ -41,6 +41,7 @@ class FeedbackMessages(object):
         MISPLACED = INCORRECT_SOLUTION
         NOT_PLACED = INCORRECT_SOLUTION
 
+    GRADE_FEEDBACK_TPL = _('Your highest score is {score}')
     FINAL_ATTEMPT_TPL = _('Final attempt was used, highest score is {score}')
 
     @staticmethod

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -2,6 +2,8 @@
     "title": "DnDv2 XBlock with plain text instructions",
     "mode": "assessment",
     "max_attempts": 10,
+    "graded": false,
+    "weighted_max_score": 5,
     "show_title": true,
     "problem_text": "Can you solve this drag-and-drop problem?",
     "show_problem_header": true,

--- a/tests/unit/data/assessment/settings.json
+++ b/tests/unit/data/assessment/settings.json
@@ -5,7 +5,7 @@
     "show_title": true,
     "question_text": "Can you solve this drag-and-drop problem?",
     "show_question_header": true,
-    "weight": 1,
+    "weight": 5,
     "item_background_color": "",
     "item_text_color": "",
     "url_name": "test"

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -2,6 +2,8 @@
     "title": "DnDv2 XBlock with HTML instructions",
     "mode": "standard",
     "max_attempts": 0,
+    "graded": false,
+    "weighted_max_score": 1,
     "show_title": false,
     "problem_text": "Solve this <strong>drag-and-drop</strong> problem.",
     "show_problem_header": false,

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -2,6 +2,8 @@
     "title": "Drag and Drop",
     "mode": "standard",
     "max_attempts": null,
+    "graded": false,
+    "weighted_max_score": 1,
     "show_title": true,
     "problem_text": "",
     "show_problem_header": true,

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -2,6 +2,8 @@
     "title": "DnDv2 XBlock with plain text instructions",
     "mode": "standard",
     "max_attempts": 0,
+    "graded": false,
+    "weighted_max_score": 1,
     "show_title": true,
     "problem_text": "Can you solve this drag-and-drop problem?",
     "show_problem_header": true,


### PR DESCRIPTION
## Description

Student's grade was not displayed on DnDv2 problems. This patch adds code to display score information beneath the display name of the problem (similar to CAPA).

It also implements the missing `max_score` method which is required by the LMS to correctly calculate and display grades on the "Progress" tab.

![screen shot 2016-10-20 at 10 10 22](https://cloud.githubusercontent.com/assets/32585/19551847/8150b9ca-96ad-11e6-86f9-612651fc91d9.png)
## JIRA
- [SOL-2030](https://openedx.atlassian.net/browse/SOL-2030)
- [SOL-2094](https://openedx.atlassian.net/browse/SOL-2094)
## Sandbox URLs

Latest commit on the sandboxe: 3ad5a184dfe6ecb6644603cc75973e19738a97da
- [DnD unit in LMS](http://pr13797.sandbox.opencraft.hosting/courses/course-v1:DnDX+DnD101+2016/courseware/ce77c57034524ffb938c2b16e8316b7d/d49d04ffc18f4e738229aab063234adf/1?activate_block_id=block-v1%3ADnDX%2BDnD101%2B2016%2Btype%40vertical%2Bblock%40631785c086ab45278755c34fa7562a31)
- [Progress page in LMS](http://pr13797.sandbox.opencraft.hosting/courses/course-v1:DnDX+DnD101+2016/progress)
- [DnD unit in Studio](http://studio-pr13797.sandbox.opencraft.hosting/container/block-v1:DnDX+DnD101+2016+type@vertical+block@631785c086ab45278755c34fa7562a31)
## Testing instructions
1. Add a new DnDv2 block using default settings (standard mode).
2. Open the problem in LMS. The grey line below the title should say: "1 point possible (graded)" or "1 point possible (ungraded)", depending on whether you created the problem in a graded or ungraded section.
3. Toggle section between graded and ungraded (in Course Outline view in Studio, click the settings icon of the subsection containing the DnDv2 problem and select "Not Graded" or any of the other options if you want the problem to be graded).
4. Refresh the page in LMS. Make sure the text changes between "(graded)" <-> "(ungraded)".
5. Open the "Progress" page. Verify that the section corresponding to the DnD problem says `0/1`.
6. Go back to the DnD problem and start dragging items to the board. As you drop each item, check that the grade updates accordingly. Also check that the grade on the "Progress" page is always in sync with the grade displayed on the DnD problem.
7. Reset the problem. Verify that resetting the problem does not reset the grade (both on the problem itself and on the "Progress" page).
8. Change max score (weight) setting in Studio. Delete student state to clear the existing grade, then check that the grades are scaled correctly for max_score.
9. Repeat the above steps with a DnD problem in "assessment" mode. In assessment mode, the grade should only update when you explicitly submit the problem, not on every drop like it does in standard mode.
## Notes and Concerns
#96 makes decoy items contribute to the final score. This has the surprising effect that the first move you do on a fresh DnD problem that includes at least one decoy item is wrong, you immediately get awarded points for the decoy item.
## Reviewers
- [x] OpenCraft: @itsjeyd
- [x] TNL: @cahrens and/or @staubina
- [ ] a11y: @edx/edx-accessibility
- [x] Product: @sstack22 
