### PR TITLE
removed duplicate msgids

### DIFF
--- a/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/en/LC_MESSAGES/text.po
@@ -562,11 +562,6 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: public/js/drag_and_drop_edit.js
-msgid "Close"
-msgstr ""
-
-
 # Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
 #: public/js/drag_and_drop.js:453
 msgid "{earned}/{possible} point (graded)"

--- a/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
+++ b/drag_and_drop_v2/translations/eo/LC_MESSAGES/text.po
@@ -690,10 +690,6 @@ msgid_plural "{possible} points possible (ungraded)"
 msgstr[0] "{possible} pöïnt pössïßlé (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
 msgstr[1] "{possible} pöïnts pössïßlé (üngrädéd) Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢т#"
 
-#: drag_and_drop_v2/public/js/drag_and_drop.js
-msgid "Close"
-msgstr "Çlösé Ⱡ'σяєм ιρѕ#"
-
 #: drag_and_drop_v2/public/js/drag_and_drop.js:374
 #: drag_and_drop_v2/public/js/drag_and_drop.js:839
 msgid "Hints:"


### PR DESCRIPTION
This PR removes duplicate msgids in source language translation file(en/text.po) and dummy translation file(eo/text.po) to get rid of this error on transifex.
```
A resource could not be auto-updated.
There is a syntax error in your file. Line 566: duplicate message definition... Line 531: ...this is the location of the first definition msgfmt: found 1 fatal error
```