### PR TITLE
Makes draggable items more visible in IE 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.14.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.15.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -183,8 +183,10 @@
 .xblock--drag-and-drop .drag-container .option[draggable='true']:hover,
 .xblock--drag-and-drop .drag-container .option[draggable='true'][aria-grabbed='true'] {
     outline-width: 2px;
-    outline-style: solid;
+    outline-style: dotted;
     outline-offset: -4px;
+    /* IE 11 doesn't support outline-offset, so we use a box-shadow instead. */
+    box-shadow: inset 0 0 0 2px;
 }
 
 .xblock--drag-and-drop .drag-container .option.grabbed-with-mouse {
@@ -266,7 +268,7 @@
 /* Focused zone */
 .xblock--drag-and-drop .item-bank:focus,
 .xblock--drag-and-drop .zone:focus {
-    outline: 2px solid #a5a5a5;
+    outline: 2px dotted #a5a5a5;
 }
 
 .xblock--drag-and-drop .drag-container .target .zone p {
@@ -423,7 +425,7 @@
 }
 
 .xblock--drag-and-drop .popup .close-feedback-popup-button:focus {
-    outline: 2px solid white;
+    outline: 2px dotted white;
 }
 
 /*** edX pattern library components ***/

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.14',
+    version='2.0.15',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
This change helps the accessibility of the DnDv2 xblock by improving the visibility of the CSS outline used to highlight focused items.

**JIRA tickets**: [TNL-6358](https://openedx.atlassian.net/browse/TNL-6358)

**Screenshots**:

* We currently set the outline color for draggable items to the (user-configurable) text color, and use `outline-offset: -4px` to inset the outline used for draggable items.  This ensures that the outline is visible against any background image.
  However, the `outline-offset` CSS property is not supported by IE, and so the outline was appearing outside the draggable items, and thus is often disguised against the background.
  So, we add a `box-shadow: inset` style to the focused draggable items, which serves to show an inset border for the draggable items when `outline-offset` is not supported.  This change works for normal contrast mode in Windows only; high-contrast mode disables `box-shadow`.
  ![outline-inset-normal1](https://cloud.githubusercontent.com/assets/7556571/22539853/b52a61b2-e96c-11e6-8fa9-c4b2952dd492.PNG)
  ![outline-inset-normal2](https://cloud.githubusercontent.com/assets/7556571/22539856/b7c7c2b6-e96c-11e6-92a9-afbd9f12d661.PNG)

* Uses `outline-style: dotted` instead of `solid`, to make the outline more visible in Windows High Contrast mode.
![outline-dotted-contrast-1](https://cloud.githubusercontent.com/assets/7556571/22539862/c248e2ba-e96c-11e6-8d0c-39f07e81cadc.PNG)
![outline-dotted-contrast-2](https://cloud.githubusercontent.com/assets/7556571/22539863/c4d90550-e96c-11e6-9ba2-76802c3d0639.PNG)

**Sandbox URL**:

* LMS: http://pr14449.sandbox.opencraft.hosting/
* Studio: http://studio-pr14449.sandbox.opencraft.hosting/

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP - we'd like to get this into the Ficus release.

**Testing instructions**:

This bug specifically relates to Windows IE, but please check other browsers too to ensure that accessibility hasn't been compromised.

1. Login to the sandbox, and enrol in the [DnDv2 course](https://preview-pr14449.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+DnDv2+2017_01/courseware/bc14eeaeeaa44bd79d6964759afde145/d4797a8146c84520bce067b6854af4f5/2?activate_block_id=block-v1%3AOpenCraft%2BDnDv2%2B2017_01%2Btype%40vertical%2Bblock%40846a331a04494993a8eff14b6bfedc64).
2. Use the keyboard to navigate the demo activity, noting the inset outline on the draggable items.
3. In Windows, [change to High Contrast Mode](https://support.microsoft.com/en-us/instantanswers/ece8e1d7-1a7c-473c-a0f4-3c9d66fee295/turn-high-contrast-mode-on-or-off-in-windows), and note the dotted outline on focusable items.

**Reviewers**
- [x] @bdero
- [x] edX TBD