### PR TITLE
implements scorablexblockmixin and moves drag and drop v2 to use raw grades.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.15.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.0.16.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/install_test_deps.sh
+++ b/install_test_deps.sh
@@ -1,6 +1,6 @@
 # Installs xblock-sdk and dependencies needed to run the tests suite.
 # Run this script inside a fresh virtual environment.
-pip install -e git://github.com/edx/xblock-sdk.git@v0.1.2#egg=xblock-sdk==v0.1.2
+pip install -e git://github.com/edx/xblock-sdk.git@v0.1.3#egg=xblock-sdk==v0.1.3
 cd $VIRTUAL_ENV/src/xblock-sdk/ && pip install -r requirements/base.txt \
                                 && pip install -r requirements/test.txt && cd -
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2
+git+https://github.com/edx/xblock-utils.git@v1.0.4#egg=xblock-utils==1.0.4
 -e .

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.15',
+    version='2.0.16',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -41,7 +41,7 @@ class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, BaseEventsT
         },
         {
             'name': 'grade',
-            'data': {'max_value': 1, 'value': (2.0 / 5)},
+            'data': {'max_value': 1, 'value': (2.0 / 5), 'only_if_higher': None},
         },
         {
             'name': 'edx.drag_and_drop_v2.item.dropped',
@@ -77,7 +77,7 @@ class EventsFiredTest(DefaultDataTestMixin, ParameterizedTestsMixin, BaseEventsT
     @unpack
     def test_event(self, index, event):
         self.parameterized_item_positive_feedback_on_good_move_standard(self.items_map)
-        dummy, name, published_data = self.publish.call_args_list[index][0]
+        _, name, published_data = self.publish.call_args_list[index][0]
         self.assertEqual(name, event['name'])
         self.assertEqual(published_data, event['data'])
 
@@ -121,7 +121,7 @@ class AssessmentEventsFiredTest(
         },
         {
             'name': 'grade',
-            'data': {'max_value': 1, 'value': (1.0 / 5)},
+            'data': {'max_value': 1, 'value': (1.0 / 5), 'only_if_higher': None},
         },
         {
             'name': 'edx.drag_and_drop_v2.feedback.opened',
@@ -143,7 +143,7 @@ class AssessmentEventsFiredTest(
         self.click_submit()
         self.wait_for_ajax()
         for index, event in enumerate(self.scenarios):
-            dummy, name, published_data = self.publish.call_args_list[index][0]
+            _, name, published_data = self.publish.call_args_list[index][0]
             self.assertEqual(name, event['name'])
             self.assertEqual(published_data, event['data'])
 
@@ -158,7 +158,7 @@ class AssessmentEventsFiredTest(
 
         events = self.publish.call_args_list
         published_grade = next((event[0][2] for event in events if event[0][1] == 'grade'))
-        expected_grade = {'max_value': 1, 'value': (1.0 / 5.0)}
+        expected_grade = {'max_value': 1, 'value': (1.0 / 5.0), 'only_if_higher': None}
         self.assertEqual(published_grade, expected_grade)
 
 

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -223,6 +223,10 @@ class TestDragAndDropRender(BaseIntegrationTest):
         # usually is not the case when running integration tests.
         # See: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/7346
         self.browser.execute_script('$("button.go-to-beginning-button").focus()')
+
+        # For unknown reasons the element only becomes visible when focus() is called twice.
+        # See: https://openedx.atlassian.net/browse/TNL-6736
+        self.browser.execute_script('$("button.go-to-beginning-button").focus()')
         self.assertFocused(button)
         # Button should be visible when focused.
         self.assertNotIn('sr', button.get_attribute('class').split())


### PR DESCRIPTION
In the course of [implementing rescore ](https://openedx.atlassian.net/browse/TNL-6593)for the drag-and-drop v2 XBlock, I uncovered [some bugs](https://openedx.atlassian.net/browse/TNL-6638) in the XBlock's handling of grades. This PR implements the abstract methods in the scorable XBlock mixin and changes the internal handling of grades to deal solely in raw, unweighted values until they need to be surfaced to learners.

I will remove my edit to requirements.txt when Cliff's work lands in the XBlock repo.

Reviewer: @jcdyer

FYI @staubina (for timing) and @bradenmacdonald (since OpenCraft built this block)