### PR TITLE
[MCKIN-5772] Adjust feedback popup styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.0.18.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.1.1.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Version 2.1.1 (2017-09-26)
+---------------------------
+
+* Enforce XBlock variable types (PR #104)
+* Improvements for mobile (PRs #132, #133, #134)
+
 Version 2.0.14 (2017-01-17)
 ---------------------------
 

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -112,6 +112,19 @@
     z-index: 10 !important;
 }
 
+@media screen and (max-width: 480px) {
+   /* Horizontal scroll for item bank on mobile */
+    .xblock--drag-and-drop .item-bank {
+        -ms-flex-flow: row nowrap;
+        flex-flow: row nowrap;
+        overflow-x: auto;
+    }
+
+    .xblock--drag-and-drop .drag-container .item-bank .option {
+        flex-shrink: 0;
+    }
+}
+
 .xblock--drag-and-drop .drag-container .option.specified-width img {
     width: 100%;  /* If the image is smaller than the specified width, make it larger */
 }
@@ -405,7 +418,7 @@
     max-width: 100%;
 }
 
-.xblock--drag-and-drop .popup .close-feedback-popup-button {
+.xblock--drag-and-drop .popup .close-feedback-popup-desktop-button {
     cursor: pointer;
     margin-top: 8px;
     color: #ffffff;
@@ -413,21 +426,109 @@
     font-size: 18pt;
 }
 
-.ltr .xblock--drag-and-drop .popup .close-feedback-popup-button {
+.xblock--drag-and-drop .popup .close-feedback-popup-mobile-button {
+    display: none;
+}
+
+.xblock--drag-and-drop .popup .popup-header-icon {
+    display: none;
+}
+
+.xblock--drag-and-drop .popup .popup-header-text {
+    display: none;
+}
+
+.xblock--drag-and-drop .popup .popup-header-icon.popup-header-icon-incorrect {
+    color: #ff143e;
+}
+
+.ltr .xblock--drag-and-drop .popup .close-feedback-popup-desktop-button {
     float: right;
     margin-right: 8px;
     margin-left: 20px;
 }
 
-.rtl .xblock--drag-and-drop .popup .close-feedback-popup-button {
+.rtl .xblock--drag-and-drop .popup .close-feedback-popup-desktop-button {
     float: left;
     margin-right: 20px;
     margin-left: 8px;
 }
 
-.xblock--drag-and-drop .popup .close-feedback-popup-button:focus {
+.xblock--drag-and-drop .popup .close-feedback-popup-desktop-button:focus {
     outline: 2px dotted white;
 }
+
+@media screen and (max-width: 480px) {
+    .xblock--drag-and-drop .popup .popup-content p {
+        text-align: center;
+    }
+
+    .xblock--drag-and-drop .popup {
+        background-color: #fff;
+        border-radius: 10px;
+        text-align: center;
+        box-shadow: 0 0 100px rgba(0,0,0,0.4);
+        border: none;
+        max-height: 90vh;
+    }
+
+    .xblock--drag-and-drop .popup .close-feedback-popup-desktop-button {
+        display: none;
+    }
+
+    .xblock--drag-and-drop .popup.popup-incorrect {
+        background-color: #fff;
+    }
+
+    .xblock--drag-and-drop .popup .popup-header-icon {
+        display: inline-block;
+        margin-top: 10px;
+        color: #629a2c;
+        font-size: 20pt;
+    }
+
+    .xblock--drag-and-drop .popup .popup-header-icon.popup-header-icon-incorrect {
+        color: #ff143e;
+    }
+
+    .xblock--drag-and-drop .popup .popup-header-text {
+        display: block;
+        padding: 2px 0 8px;
+        font-weight: 600;
+    }
+
+    .xblock--drag-and-drop .popup .popup-content {
+        color: #629a2c;
+        margin: 10px 0px 0px 0px;
+        font-size: 14px;
+        background-color: #f4ffe7;
+        padding: 20px;
+        border-color: #eee;
+        border-style: solid;
+        border-width: 1px 0 1px 0;
+    }
+
+    .xblock--drag-and-drop .popup .popup-content ul {
+        list-style-position: inside;
+        padding: 0;
+    }
+
+    .xblock--drag-and-drop .popup .popup-content.popup-content-incorrect {
+        color: #ff143e;
+        background-color: #ffe8ec;
+    }
+
+    .xblock--drag-and-drop .popup .close-feedback-popup-mobile-button {
+        display: inline;
+        cursor: pointer;
+        margin-top: 10px;
+        margin-bottom: 10px;
+        color: #3384ca;
+        font-size: 12pt;
+        padding: 10px;
+    }
+}
+
 
 /*** edX pattern library components ***/
 
@@ -583,19 +684,6 @@
     .rtl .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
         float: left;
         padding-left: -5px;
-    }
-}
-
-@media screen and (max-width: 480px) {
-   /* Horizontal scroll for item bank on mobile */
-    .xblock--drag-and-drop .drag-container .item-bank .option {
-        flex-shrink: 0;
-    }
-
-    .xblock--drag-and-drop .item-bank {
-        -ms-flex-flow: row nowrap;
-        flex-flow: row nowrap;
-        overflow-x: auto;
     }
 }
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -427,11 +427,19 @@ function DragAndDropTemplates(configuration) {
                     return h("li", {innerHTML: message.message});
                 }))
             ];
-            popup_content = h("div.popup-content", {}, have_messages ? content_items : []);
+            popup_content = h(
+                ctx.last_action_correct ? "div.popup-content" : "div.popup-content.popup-content-incorrect",
+                {},
+                have_messages ? content_items : []
+            );
         } else {
-            popup_content = h("div.popup-content", {}, msgs.map(function(message) {
-                return h("p", {innerHTML: message.message});
-            }))
+            popup_content = h(
+                ctx.last_action_correct ? "div.popup-content" : "div.popup-content.popup-content-incorrect",
+                {},
+                msgs.map(function(message) {
+                    return h("p", {innerHTML: message.message});
+                })
+            );
         }
 
         return h(
@@ -441,7 +449,7 @@ function DragAndDropTemplates(configuration) {
             },
             [
                 h(
-                    'button.unbutton.close-feedback-popup-button',
+                    'button.unbutton.close-feedback-popup-button.close-feedback-popup-desktop-button',
                     {},
                     [
                         h(
@@ -460,7 +468,37 @@ function DragAndDropTemplates(configuration) {
                         )
                     ]
                 ),
-                popup_content
+                h(
+                    ctx.last_action_correct ? 'div.popup-header-icon' : 'div.popup-header-icon.popup-header-icon-incorrect',
+                    {},
+                    [
+                        h(
+                            ctx.last_action_correct ? 'span.icon.fa.fa-check-circle' : 'span.icon.fa.fa-exclamation-circle',
+                            {
+                                attributes: {
+                                    'aria-hidden': true
+                                }
+                            }
+                        )
+                    ]
+                ),
+                h(
+                    'div.popup-header-text',
+                    {},
+                    ctx.last_action_correct ? gettext("Correct") : gettext("Incorrect")
+                ),
+                popup_content,
+                h(
+                    'button.unbutton.close-feedback-popup-button.close-feedback-popup-mobile-button',
+                    {},
+                    [
+                        h(
+                            'span',
+                            {},
+                            gettext("Close")
+                        )
+                    ]
+                )
             ]
         )
     };
@@ -1092,7 +1130,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     var focusItemFeedbackPopup = function() {
         var popup = $root.find('.item-feedback-popup');
         if (popup.length && popup.is(":visible")) {
-            popup.find('.close-feedback-popup-button').focus();
+            popup.find('.close-feedback-popup-button:visible').focus();
             return true;
         }
         return false;

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.0.18',
+    version='2.1.1',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
Change the feedback popup styles for mobile.

**JIRA tickets**: Implements SOL-5, SOL-6.

**Dependencies**: None

**Screenshots**:
These are the new screenshots that display with the changes in this PR.

<img width="564" alt="screen shot 2017-09-22 at 3 11 45 am" src="https://user-images.githubusercontent.com/395294/30733194-fa52a15e-9f43-11e7-8e29-1e7deea962d3.png">
<img width="568" alt="screen shot 2017-09-22 at 3 12 18 am" src="https://user-images.githubusercontent.com/395294/30733195-fa6d34ba-9f43-11e7-8934-d69d1ecd2ddb.png">


**Merge deadline**: ASAP.

**Testing instructions**:

1. Add the Drag and Drop demo course to your courses. Alternatively, you can just add a Drag and Drop component to your existing course (for eg Problem Builder demo course)
2. Go to the  "Multiple Blocks Test" unit in the DnD demo or the PB demo course and drag and drop blocks to the target zone.

**Author notes and concerns**:

1. I have changed the current CSS just so that I can get feedback about the changes. Still have to add conditions to the code to have the changes appear only for mobile.
2. Looking for feedback on the right color codes, icons, etc and more since I have used some defaults just to get the code working at first.

**Reviewers**
- [ ] @mtyaka 
- [ ] @bradenmacdonald 
