### PR TITLE
[MCKIN-5773] When running on mobile, make the item bank scrollable in the x direction without wrapping the items

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -586,6 +586,19 @@
     }
 }
 
+@media screen and (max-width: 480px) {
+   /* Horizontal scroll for item bank on mobile */
+    .xblock--drag-and-drop .drag-container .item-bank .option {
+        flex-shrink: 0;
+    }
+
+    .xblock--drag-and-drop .item-bank {
+        -ms-flex-flow: row nowrap;
+        flex-flow: row nowrap;
+        overflow-x: auto;
+    }
+}
+
 .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
     border-collapse: collapse;
     padding: 0 5px;


### PR DESCRIPTION
Allows items in the item bank to be scrolled horizontally on mobile.

**JIRA tickets**: [OC-3061](https://tasks.opencraft.com/browse/OC-3061) [MCKIN-5773](https://edx-wiki.atlassian.net/browse/MCKIN-5773)

**Screenshots**: 
![screen shot 2017-09-24 at 8 39 16 am](https://user-images.githubusercontent.com/1826172/30780122-f08f520e-a103-11e7-9089-cec39ab0f0ff.png)

**Merge deadline**: None

**Testing instructions**:

1. Add drag and drop to a course, and enable for mobile. Ensure that there are enough choices to take up more horizontal space than typically available on mobile.
1. In a mobile app, navigate to the xblock. Rather than wrapping, the blocks now extend horizontally, and you can scroll across by dragging the area between the blocks.
1. Ensure that other interactions work as expected
1. Behaviour should not be changed on desktop version.

**Author notes and concerns**:

1. Is the `.chromeless` CSS class the best way to target elements on mobile?

**Reviewers**
- [ ] @mtyaka 