### PR TITLE
When running on mobile, make the target image scroll in the x direction

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -249,6 +249,23 @@
     height: auto;
 }
 
+@media screen and (max-width: 480px) {
+    .xblock--drag-and-drop .target {
+        overflow: auto;
+        display: block;
+    }
+
+    .xblock--drag-and-drop .target-img {
+        max-width: none;
+        width: auto;
+    }
+
+    .xblock--drag-and-drop .target-img-wrapper {
+        display: inline-block;
+        position: relative;
+    }
+}
+
 .xblock--drag-and-drop .zone {
     position: absolute;
 

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -3,6 +3,18 @@
     max-width: 770px;
     margin: 0;
     padding: 0;
+    position: relative;
+}
+
+.xblock--drag-and-drop .resize-detector {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: -1;
 }
 
 .xblock--drag-and-drop .initial-load-spinner {
@@ -64,6 +76,7 @@
 /* drag-container holds the .items and the .target image */
 
 .xblock--drag-and-drop .drag-container {
+    box-sizing: border-box;
     width: auto;
     padding: 1%;
     background-color: #ebf0f2;
@@ -122,6 +135,8 @@
 
     .xblock--drag-and-drop .drag-container .item-bank .option {
         flex-shrink: 0;
+        flex-grow: 0;
+        max-width: 80%;
     }
 }
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -643,8 +643,8 @@ function DragAndDropTemplates(configuration) {
                         itemFeedbackPopupTemplate(ctx),
                         h('div.target-img-wrapper', [
                             h('img.target-img', {src: ctx.target_img_src, alt: ctx.target_img_description}),
+                            renderCollection(zoneTemplate, ctx.zones, ctx)
                         ]),
-                        renderCollection(zoneTemplate, ctx.zones, ctx)
                     ]),
                     h('div.dragged-items', renderCollection(itemTemplate, items_dragged, ctx)),
                 ]),

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -82,7 +82,7 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
     EXPECTATIONS = [
         # The text 'Auto' with no fixed size specified should be 5-20% wide
-        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[5, AUTO_MAX_WIDTH]),
+        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[3, AUTO_MAX_WIDTH]),
         # The long text with no fixed size specified should be wrapped at the maximum width
         Expectation(item_id=1, zone_id=ZONE_33, width_percent=AUTO_MAX_WIDTH),
         # The text items that specify specific widths as a percentage of the background image:
@@ -90,9 +90,9 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         Expectation(item_id=3, zone_id=ZONE_50, fixed_width_percent=50),
         Expectation(item_id=4, zone_id=ZONE_75, fixed_width_percent=75),
         # A 400x300 image with automatic sizing should be constrained to the maximum width
-        Expectation(item_id=5, zone_id=ZONE_50, width_percent=AUTO_MAX_WIDTH),
+        Expectation(item_id=5, zone_id=ZONE_50, width_percent=[26, AUTO_MAX_WIDTH]),
         # A 200x200 image with automatic sizing
-        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[25, 30.2]),
+        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[13, 30.2]),
         # A 400x300 image with a specified width of 50%
         Expectation(item_id=7, zone_id=ZONE_50, fixed_width_percent=50),
         # A 200x200 image with a specified width of 50%
@@ -130,12 +130,12 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
     def test_wide_image_mobile(self):
         """ Test the upper, larger, wide image in a mobile-sized window """
         self._size_for_mobile()
-        self._check_sizes(0, self.EXPECTATIONS, is_desktop=False)
+        self._check_sizes(0, self.EXPECTATIONS, expected_img_width=1600, is_desktop=False)
 
     def test_square_image_mobile(self):
         """ Test the lower, smaller, square image in a mobile-sized window """
         self._size_for_mobile()
-        self._check_sizes(1, self.EXPECTATIONS, is_desktop=False)
+        self._check_sizes(1, self.EXPECTATIONS, expected_img_width=500, is_desktop=False)
 
     def _check_width(self, item_description, item, container_width, expected_percent):
         """
@@ -213,13 +213,13 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
                     container_width=item_bank_width,
                     expected_percent=expect.width_percent,
                 )
-            if expect.fixed_width_percent is not None:
-                self._check_width(
-                    item_description="Unplaced item {} with fixed width".format(expect.item_id),
-                    item=self._get_unplaced_item_by_value(expect.item_id),
-                    container_width=target_img_width,
-                    expected_percent=expect.fixed_width_percent,
-                )
+            # if expect.fixed_width_percent is not None:
+            #     self._check_width(
+            #         item_description="Unplaced item {} with fixed width".format(expect.item_id),
+            #         item=self._get_unplaced_item_by_value(expect.item_id),
+            #         container_width=target_img_width,
+            #         expected_percent=expect.fixed_width_percent,
+            #     )
             if expect.img_pixel_size_exact is not None:
                 self._check_img_pixel_dimensions(
                     "Unplaced item {}".format(expect.item_id),

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -24,6 +24,8 @@ def _svg_to_data_uri(path):
 Expectation = namedtuple('Expectation', [
     'item_id',
     'zone_id',
+    'width_percent_bank',  # we expect this item to have this width relative to its container (item bank)
+    'width_percent_image',  # we expect this item to have this width relative to its container (image target)
     'width_percent',  # we expect this item to have this width relative to its container (item bank or image target)
     'fixed_width_percent',  # we expect this item to have this width (always relative to the target image)
     'img_pixel_size_exact',  # we expect the image inside the draggable to have the exact size [w, h] in pixels
@@ -32,7 +34,15 @@ Expectation.__new__.__defaults__ = (None,) * len(Expectation._fields)  # pylint:
 ZONE_33 = "Zone 1/3"  # Title of top zone in each image used in these tests (33% width)
 ZONE_50 = "Zone 50%"
 ZONE_75 = "Zone 75%"
-AUTO_MAX_WIDTH = 30  # Maximum width (as % of the parent container) for items with automatic sizing
+
+# iPhone 6 viewport size is 375x627; this is the closest Chrome can get.
+MOBILE_WINDOW_WIDTH = 400
+MOBILE_WINDOW_HEIGHT = 627
+
+# Maximum widths (as % of the parent container) for items with automatic sizing
+AUTO_MAX_WIDTH_DESKTOP = 30
+AUTO_MAX_WIDTH_MOBILE_ITEM_BANK = 80
+AUTO_MAX_WIDTH_MOBILE_TARGET_IMG = 30
 
 
 class SizingTests(InteractionTestBase, BaseIntegrationTest):
@@ -80,19 +90,62 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
         return "<vertical_demo>{}\n{}</vertical_demo>".format(upper_block, lower_block)
 
-    EXPECTATIONS = [
-        # The text 'Auto' with no fixed size specified should be 5-20% wide
-        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[3, AUTO_MAX_WIDTH]),
+    EXPECTATIONS_DESKTOP = [
+        # The text 'Auto' with no fixed size specified should be 3-20% wide
+        Expectation(item_id=0, zone_id=ZONE_33, width_percent=[3, AUTO_MAX_WIDTH_DESKTOP]),
         # The long text with no fixed size specified should be wrapped at the maximum width
-        Expectation(item_id=1, zone_id=ZONE_33, width_percent=AUTO_MAX_WIDTH),
+        Expectation(item_id=1, zone_id=ZONE_33, width_percent=AUTO_MAX_WIDTH_DESKTOP),
         # The text items that specify specific widths as a percentage of the background image:
         Expectation(item_id=2, zone_id=ZONE_33, fixed_width_percent=33.3),
         Expectation(item_id=3, zone_id=ZONE_50, fixed_width_percent=50),
         Expectation(item_id=4, zone_id=ZONE_75, fixed_width_percent=75),
         # A 400x300 image with automatic sizing should be constrained to the maximum width
-        Expectation(item_id=5, zone_id=ZONE_50, width_percent=[26, AUTO_MAX_WIDTH]),
+        Expectation(item_id=5, zone_id=ZONE_50, width_percent=AUTO_MAX_WIDTH_DESKTOP),
         # A 200x200 image with automatic sizing
-        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[13, 30.2]),
+        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[25, 30.2]),
+        # A 400x300 image with a specified width of 50%
+        Expectation(item_id=7, zone_id=ZONE_50, fixed_width_percent=50),
+        # A 200x200 image with a specified width of 50%
+        Expectation(item_id=8, zone_id=ZONE_50, fixed_width_percent=50),
+        # A 60x60 auto-sized image should appear with pixel dimensions of 60x60 since it's
+        # too small to be shrunk be the default max-size.
+        Expectation(item_id=9, zone_id=ZONE_33, img_pixel_size_exact=[60, 60]),
+    ]
+
+    EXPECTATIONS_MOBILE = [
+        # The text 'Auto' with no fixed size specified should be 3-20% wide
+        Expectation(
+            item_id=0,
+            zone_id=ZONE_33,
+            width_percent_bank=[3, AUTO_MAX_WIDTH_MOBILE_TARGET_IMG],
+            width_percent_image=[3, AUTO_MAX_WIDTH_MOBILE_ITEM_BANK],
+        ),
+        # The long text with no fixed size specified should be wrapped at the maximum width
+        Expectation(
+            item_id=1,
+            zone_id=ZONE_33,
+            width_percent_bank=AUTO_MAX_WIDTH_MOBILE_ITEM_BANK,
+            width_percent_image=AUTO_MAX_WIDTH_MOBILE_TARGET_IMG,
+        ),
+        # The text items that specify specific widths as a percentage of the background image:
+        Expectation(item_id=2, zone_id=ZONE_33, fixed_width_percent=33.3),
+        Expectation(item_id=3, zone_id=ZONE_50, fixed_width_percent=50),
+        Expectation(item_id=4, zone_id=ZONE_75, fixed_width_percent=75),
+        # A 400x300 image with automatic sizing should be constrained to the maximum width,
+        # except on a large background image, where its natural size is smaller than max allowed size.
+        Expectation(
+            item_id=5,
+            zone_id=ZONE_50,
+            width_percent_bank=AUTO_MAX_WIDTH_MOBILE_ITEM_BANK,
+            width_percent_image=[25, AUTO_MAX_WIDTH_MOBILE_TARGET_IMG],
+        ),
+        # A 200x200 image with automatic sizing
+        Expectation(
+            item_id=6,
+            zone_id=ZONE_50,
+            width_percent_bank=[60, AUTO_MAX_WIDTH_MOBILE_ITEM_BANK],
+            width_percent_image=[10, AUTO_MAX_WIDTH_MOBILE_ITEM_BANK],
+        ),
         # A 400x300 image with a specified width of 50%
         Expectation(item_id=7, zone_id=ZONE_50, fixed_width_percent=50),
         # A 200x200 image with a specified width of 50%
@@ -104,17 +157,16 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
     def test_wide_image_desktop(self):
         """ Test the upper, larger, wide image in a desktop-sized window """
-        self._check_sizes(0, self.EXPECTATIONS)
+        self._check_sizes(0, self.EXPECTATIONS_DESKTOP)
 
     def test_square_image_desktop(self):
         """ Test the lower, smaller, square image in a desktop-sized window """
-        self._check_sizes(1, self.EXPECTATIONS, expected_img_width=500)
+        self._check_sizes(1, self.EXPECTATIONS_DESKTOP, expected_img_width=500)
 
     def _size_for_mobile(self):
-        width, height = 400, 627  # iPhone 6 viewport size is 375x627; this is the closest Chrome can get
-        self.browser.set_window_size(width, height)
+        self.browser.set_window_size(MOBILE_WINDOW_WIDTH, MOBILE_WINDOW_HEIGHT)
         wait = WebDriverWait(self.browser, 2)
-        wait.until(lambda browser: browser.get_window_size()["width"] == width)
+        wait.until(lambda browser: browser.get_window_size()["width"] == MOBILE_WINDOW_WIDTH)
         # Fix platform inconsistencies caused by scrollbar size:
         self.browser.execute_script('$("body").css("margin-right", "40px")')
         scrollbar_width = self.browser.execute_script(
@@ -127,15 +179,23 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         # And reduce the wasted space around our XBlock in the workbench:
         self.browser.execute_script('return $(".workbench .preview").css("margin", "0")')
 
+    def _check_mobile_container_size(self):
+        """ Verify that the drag-container tightly fits into the available space. """
+        drag_container = self._page.find_element_by_css_selector('.drag-container')
+        horizontal_padding = 20
+        self.assertEqual(drag_container.size['width'], MOBILE_WINDOW_WIDTH - 2*horizontal_padding)
+
     def test_wide_image_mobile(self):
         """ Test the upper, larger, wide image in a mobile-sized window """
         self._size_for_mobile()
-        self._check_sizes(0, self.EXPECTATIONS, expected_img_width=1600, is_desktop=False)
+        self._check_mobile_container_size()
+        self._check_sizes(0, self.EXPECTATIONS_MOBILE, expected_img_width=1600, is_desktop=False)
 
     def test_square_image_mobile(self):
         """ Test the lower, smaller, square image in a mobile-sized window """
         self._size_for_mobile()
-        self._check_sizes(1, self.EXPECTATIONS, expected_img_width=500, is_desktop=False)
+        self._check_mobile_container_size()
+        self._check_sizes(1, self.EXPECTATIONS_MOBILE, expected_img_width=500, is_desktop=False)
 
     def _check_width(self, item_description, item, container_width, expected_percent):
         """
@@ -206,20 +266,21 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
         # Test each element, before it is placed (while it is in the item bank).
         for expect in expectations:
-            if expect.width_percent is not None:
+            expected_width_percent = expect.width_percent_bank or expect.width_percent
+            if expected_width_percent is not None:
                 self._check_width(
                     item_description="Unplaced item {}".format(expect.item_id),
                     item=self._get_unplaced_item_by_value(expect.item_id),
                     container_width=item_bank_width,
-                    expected_percent=expect.width_percent,
+                    expected_percent=expected_width_percent
                 )
-            # if expect.fixed_width_percent is not None:
-            #     self._check_width(
-            #         item_description="Unplaced item {} with fixed width".format(expect.item_id),
-            #         item=self._get_unplaced_item_by_value(expect.item_id),
-            #         container_width=target_img_width,
-            #         expected_percent=expect.fixed_width_percent,
-            #     )
+            if expect.fixed_width_percent is not None:
+                self._check_width(
+                    item_description="Unplaced item {} with fixed width".format(expect.item_id),
+                    item=self._get_unplaced_item_by_value(expect.item_id),
+                    container_width=target_img_width,
+                    expected_percent=expect.fixed_width_percent,
+                )
             if expect.img_pixel_size_exact is not None:
                 self._check_img_pixel_dimensions(
                     "Unplaced item {}".format(expect.item_id),
@@ -230,7 +291,10 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         # Test each element, after it it placed.
         for expect in expectations:
             self.place_item(expect.item_id, expect.zone_id, action_key=Keys.RETURN)
-            expected_width_percent = expect.fixed_width_percent or expect.width_percent
+            if expect.fixed_width_percent:
+                expected_width_percent = expect.fixed_width_percent
+            else:
+                expected_width_percent = expect.width_percent_image or expect.width_percent
             if expected_width_percent is not None:
                 self._check_width(
                     item_description="Placed item {}".format(expect.item_id),


### PR DESCRIPTION
On desktop the target image automatically shrinks/grows with its container. On mobile this often is not convenient because the image can shrink too much. We want to restrict the minimum width of the image on mobile and make the image scrollable in the x direction.

**Dependencies**: None

**Screenshots**: Here are the before and after screenshots for the different demo apps

Buckets:

Before:
![buckets_orig](https://user-images.githubusercontent.com/395294/31001054-b527fe9c-a4ae-11e7-8469-989feecdb554.png)

After:
![buckets](https://user-images.githubusercontent.com/395294/31000729-e26706d0-a4ab-11e7-826b-2bc426ce9a9c.png)

Maps:

Before:
![maps_orig](https://user-images.githubusercontent.com/395294/31001102-34dc3cde-a4af-11e7-8b58-269b3b8548cb.png)

After:
![maps](https://user-images.githubusercontent.com/395294/31000780-39871932-a4ac-11e7-9cc3-5e7e5177c5f3.png)

Multiple blocks:

Before:
![blocks_orig](https://user-images.githubusercontent.com/395294/31001142-8f484ec4-a4af-11e7-9a66-0e58fb8aec41.png)

After:
![multipleblocks](https://user-images.githubusercontent.com/395294/31000791-5bf3eba8-a4ac-11e7-919a-80e3704311d8.png)


**Merge deadline**: ASAP.

**Testing instructions**:
1. Add a drag and drop demo unit to the course.
2. On a mobile device (less than 480px wide) check that the target image does not shrink and can be scrolled horizontally.

**Author notes and concerns**:
The testing was mostly done using firefox responsive design mode, and one LG android phone.

**Reviewers**
- [ ] @bradenmacdonald 