### PR TITLE
Set max-width of drag container to available width.

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -64,6 +64,7 @@
 /* drag-container holds the .items and the .target image */
 
 .xblock--drag-and-drop .drag-container {
+    box-sizing: border-box;
     width: auto;
     padding: 1%;
     background-color: #ebf0f2;


### PR DESCRIPTION
Measure the available width before rendering the drag container. Set the drag-container's max-width to the measured available width.

Tests TBD.

**Screenshots**:

**Before**:

![screen shot 2017-10-03 at 12 29 11](https://user-images.githubusercontent.com/32585/31120929-89b8fde8-a836-11e7-8d03-a346233969db.png)

**After**:

![screen shot 2017-10-03 at 12 28 35](https://user-images.githubusercontent.com/32585/31120936-8f5142e2-a836-11e7-97a0-796f41322b93.png)


**Testing instructions**:

1. Set up a DnDv2 problem with a wide background image.
1. View the problem on a small screen (or resize you browser window).
1. Observe that without this patch, the DnDv2 problem overflows.
1. Observe that this patch fixes the problem and does not cause any issues in desktop view.