### PR TITLE
Fix: in IE11, the resize detector was blocking content

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -15,6 +15,7 @@
     overflow: hidden;
     pointer-events: none;
     z-index: -1;
+    visibility: hidden;
 }
 
 .xblock--drag-and-drop .initial-load-spinner {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -648,6 +648,7 @@ function DragAndDropTemplates(configuration) {
         // image to 100%, so that it doesn't expand the container.
         if (ctx.drag_container_max_width === null) {
             target_img_style.maxWidth = '100%';
+            item_bank_properties.style = {display: 'none'};
         } else {
             drag_container_style.maxWidth = ctx.drag_container_max_width + 'px';
         }

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -178,6 +178,9 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         self.browser.execute_script('$(".wrapper-workbench").css("margin-right", "-{}px")'.format(40 + scrollbar_width))
         # And reduce the wasted space around our XBlock in the workbench:
         self.browser.execute_script('return $(".workbench .preview").css("margin", "0")')
+        # Dynamically adjusting styles causes available screen width to change, but does not always emit
+        # resize events consistently, so emit resize manually to make sure the block adapts to the new size.
+        self.browser.execute_script('$(window).resize()')
 
     def _check_mobile_container_size(self):
         """ Verify that the drag-container tightly fits into the available space. """


### PR DESCRIPTION
This PR fixes a bug introduced in 77192dce2f4cbac825b50d67fdb0bad45bdf43f2, which causes the Drag and Drop XBlock to be unusable in IE11. The problem was that the "about:blank" `<object>` (used for consistent resize detection) was obscuring the entire XBlock.

**Before** (with the size of the problem element reduced to make the effect obvious):
![screen shot 2017-10-18 at 3 30 54 pm](https://user-images.githubusercontent.com/945577/31745875-6c948554-b419-11e7-94df-2753ebd19207.png)

**After**:
![screen shot 2017-10-18 at 3 31 06 pm](https://user-images.githubusercontent.com/945577/31745882-725c60f6-b419-11e7-9547-9274a1d4e8bb.png)

**Reviewers**:

TBD

**Testing Instructions**:

1. Try to use this XBlock in IE11. Confirm that it works. Note there is a separate issue with IE11 and blocks that use SVG images for the background, so test a block with a .jpg or .png background.
2. Test in some other browsers, and test the resize detection to make sure there's no adverse impact from this change.