### PR TITLE
Fixes failure when loading background image on IE11

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -978,6 +978,14 @@ function DragAndDropBlock(runtime, element, configuration) {
         var promise = $.Deferred();
         var img = new Image();
         img.addEventListener("load", function() {
+            if (img.width == 0 || img.height == 0) {
+                // Workaround for IE11 issue with SVG images
+                document.body.appendChild(img);
+                var width = img.offsetWidth;
+                var height = img.offsetHeight;
+                document.body.removeChild(img);
+                img.width = width, img.height = height;
+            }
             if (img.width > 0 && img.height > 0) {
                 promise.resolve(img);
             } else {


### PR DESCRIPTION
Image.height and Image.width returns 0 for SVGs loaded in JavaScript on IE11, includes a workaround to get the height and width of the SVG when they are set to 0.

**Testing Instructions**
1. Attempt to load a drag and drop block which uses an SVG for the background in Internet Explorer 11 (the [opencraft drag-and-drop-v2 demo course](https://github.com/open-craft/demo-courses) contains a few)
2. Load the same block in other browsers to ensure this doesn't alter functionality elsewhere

**Reviewers**
TBD

