### PR TITLE
Use fixed positioning for mobile popups.

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -430,7 +430,6 @@
 
 .xblock--drag-and-drop .popup {
     position: absolute;
-    display: none;
     top: 5%;
     right: 5%;
     border: 1px solid #fff;
@@ -503,12 +502,19 @@
     }
 
     .xblock--drag-and-drop .popup {
+        display: flex;
+        flex-direction: column;
         background-color: #fff;
         border-radius: 10px;
         text-align: center;
         box-shadow: 0 0 100px rgba(0,0,0,0.4);
         border: none;
         max-height: 90vh;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        right: auto;
+        transform: translate(-50%, -50%);
     }
 
     .xblock--drag-and-drop .popup .close-feedback-popup-desktop-button {
@@ -545,6 +551,8 @@
         border-color: #eee;
         border-style: solid;
         border-width: 1px 0 1px 0;
+        flex-shrink: 1;
+        overflow: auto;
     }
 
     .xblock--drag-and-drop .popup .popup-content ul {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -446,10 +446,15 @@ function DragAndDropTemplates(configuration) {
             );
         }
 
+        var popup_style = {};
+        if (!have_messages) {
+            popup_style.display = 'none';
+        }
+
         return h(
             popupSelector,
             {
-                style: {display: have_messages ? 'block' : 'none'}
+                style: popup_style
             },
             [
                 h(
@@ -493,13 +498,18 @@ function DragAndDropTemplates(configuration) {
                 ),
                 popup_content,
                 h(
-                    'button.unbutton.close-feedback-popup-button.close-feedback-popup-mobile-button',
-                    {},
+                    'div',
                     [
                         h(
-                            'span',
+                            'button.unbutton.close-feedback-popup-button.close-feedback-popup-mobile-button',
                             {},
-                            gettext("Close")
+                            [
+                                h(
+                                    'span',
+                                    {},
+                                    gettext("Close")
+                                )
+                            ]
                         )
                     ]
                 )


### PR DESCRIPTION
Fixed positioning allows us to maximize the usage of screen space and fixes some issues with popups containing a lot of content and overflowing the DnD container.

---

**Screenshots BEFORE**

![screen shot 2017-10-24 at 09 35 58](https://user-images.githubusercontent.com/32585/31930260-73a1b1c0-b89f-11e7-8f16-076b77bc87f0.png)

![screen shot 2017-10-24 at 09 36 17](https://user-images.githubusercontent.com/32585/31930261-73b93f98-b89f-11e7-867e-29c349c953a6.png)

![screen shot 2017-10-24 at 09 36 37](https://user-images.githubusercontent.com/32585/31930262-73cf7c40-b89f-11e7-9648-b850ce697c43.png)

---

**Screenshots AFTER**

![screen shot 2017-10-24 at 09 11 44](https://user-images.githubusercontent.com/32585/31930284-854e16ac-b89f-11e7-9aba-b995b08405da.png)

![screen shot 2017-10-24 at 09 12 09](https://user-images.githubusercontent.com/32585/31930283-853629d4-b89f-11e7-9f10-4505bc0aa6ed.png)

---

**Testing instructions**:

1. Checkout this branch and verify that popups are visible and centered on the screen, even when they contain a lot of content. Verify that the inner content of the popup is scrollable when it contains a lot of content.
2. Verify that desktop popups still looks and act the same as before.

**Notes**:

You might need fixes from #141 for the DnDv2 block to resize correctly in a mobile window.

**Reviewers**:

- [ ] @bradenmacdonald (?)
- [ ] @sanfordstudent (?)
