### PR TITLE
Prevent context menu on option long tap in iOS.

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -123,6 +123,7 @@
     outline-style: none;
     /* Some versions of the drag and drop library try to fiddle with this */
     z-index: 10 !important;
+    -webkit-touch-callout: none;
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
If the option contains an image, iOS would pop up a menu with image related options. We fixed a similar problem in Android where we prevent default action on contextmenu events, but that does not seem to work on iOS, which requires a special CSS property.

**Testing instructions**:

1. Add DnDv2 problem to your course.
2. Edit the DnDv2 problem and set an image URL on at least one of the draggable items.
3. Open the problem in chromeless view in mobile Safari.
4. Try to drag the item with the image.
5. Notice that without this patch, the context menu pops up, preventing you from dragging.
6. Notice that with this patch, there is no context menu and dragging works as expected.

**Reviewers**:

- [ ] @bradenmacdonald (?)
- [ ] @sanfordstudent (?)