### PR TITLE
Mention where to locate the block instead of how to install it

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,11 @@ potentially diverse audiences.
 Enabling in Studio
 ------------------
 
-You can enable the Drag and Drop XBlock in Studio through the Advanced
-Settings.
+Drag and Drop v2 XBlock is already included in Open edX.
 
-1. From the main page of a specific course, navigate to `Settings ->
-   Advanced Settings` from the top menu.
-2. Check for the `Advanced Module List` policy key, and add
-   `"drag-and-drop-v2"` to the policy value list.
-3. Click the "Save changes" button.
-4. You should see the new block `Drag and Drop` in the
-   `"Add New Component"` box. Click the green `Problem` button,
-   choose the the `Advanced` tab and choose `Drag and Drop`.
+You will find it in `"Add New Component"` box in Studio:
+click the green `Problem` button, choose the the `Advanced` tab
+and choose `Drag and Drop`.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Settings.
 2. Check for the `Advanced Module List` policy key, and add
    `"drag-and-drop-v2"` to the policy value list.
 3. Click the "Save changes" button.
+4. You should see the new block `Drag and Drop` in the
+   `"Add New Component"` box. Click the green `Problem` button,
+   choose the the `Advanced` tab and choose `Drag and Drop`.
 
 Usage
 -----


### PR DESCRIPTION
Explicitly mention where to find this block, because it doesn't appear in the usual place (Advanced) as other xblocks. Remove installation instruction because it doesn't need installation.
Note that the [documentation](http://edx.readthedocs.io/projects/xblock-tutorial/en/latest/edx_platform/devstack.html#add-an-instance-of-the-xblock-to-a-unit) is asking users to look only under „Advanced“.