### PR TITLE
Bump version to v2.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.1.4.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.1.5.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.1.4',
+    version='2.1.5',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
Per the release notes at the bottom of the README, I've updated the `.travis.yml` and `setup.py` files to update the version.

Someone else will have to create the new release in the Github UI since I don't have access to this repo.

Once this is merged, I will have a PR in the edx-platform repo to require the new v2.1.5 version. I'm also not very clear on whether the cross-fork merge will preserve the `v2.1.5` tag I created, so that might also have to be created after this is merged.

FYI: @awaisdar001 @ssemenova