### PR TITLE
Ensures URLs are utf-8 encoded. Fixes #150

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -831,13 +831,13 @@ class DragAndDropBlock(
         for this.
         """
         if hasattr(self.runtime, 'replace_urls'):
-            url = self.runtime.replace_urls('"{}"'.format(url))[1:-1]
+            url = self.runtime.replace_urls(u'"{}"'.format(url))[1:-1]
         elif hasattr(self.runtime, 'course_id'):
             # edX Studio uses a different runtime for 'studio_view' than 'student_view',
             # and the 'studio_view' runtime doesn't provide the replace_urls API.
             try:
                 from static_replace import replace_static_urls  # pylint: disable=import-error
-                url = replace_static_urls('"{}"'.format(url), None, course_id=self.runtime.course_id)[1:-1]
+                url = replace_static_urls(u'"{}"'.format(url), None, course_id=self.runtime.course_id)[1:-1]
             except ImportError:
                 pass
         return url


### PR DESCRIPTION
There might be more places where this is happening. These two are the ones affecting us right now. 

Here is one instance: 
![](https://user-images.githubusercontent.com/35380692/35053666-c553309a-fb78-11e7-980f-479964627d8c.png)
