### PR TITLE
MCKIN-6681 Improve image handling in DnDv2 on mobile

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -209,17 +209,17 @@ function DragAndDropTemplates(configuration) {
         var items_in_zone = $.grep(ctx.items, is_item_in_zone);
         var zone_description_id = zone.prefixed_uid + '-description';
         if (items_in_zone.length == 0) {
-          var zone_description = h(
-            'div',
-            { id: zone_description_id, className: 'sr'},
-            gettext("No items placed here")
-          );
+            var zone_description = h(
+                'div',
+                { id: zone_description_id, className: 'sr'},
+                gettext("No items placed here")
+            );
         } else {
-          var zone_description = h(
-            'div',
-            { id: zone_description_id, className: 'sr'},
-            gettext('Items placed here: ') + items_in_zone.map(function (item) { return item.displayName; }).join(", ")
-          );
+            var zone_description = h(
+                'div',
+                { id: zone_description_id, className: 'sr'},
+                gettext('Items placed here: ') + items_in_zone.map(function (item) { return item.displayName; }).join(", ")
+            );
         }
 
         return (
@@ -542,14 +542,14 @@ function DragAndDropTemplates(configuration) {
         if (ctx.grade !== null && ctx.weighted_max_score > 0) {
             if (is_graded) {
                 progress_template = ngettext(
-                      // Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
+                    // Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
                     '{earned}/{possible} point (graded)',
                     '{earned}/{possible} points (graded)',
                     ctx.weighted_max_score
                 );
             } else {
                 progress_template = ngettext(
-                      // Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
+                    // Translators: {earned} is the number of points earned. {possible} is the total number of points (examples: 0/1, 1/1, 2/3, 5/10). The total number of points will always be at least 1. We pluralize based on the total number of points (example: 0/1 point; 1/2 points).
                     '{earned}/{possible} point (ungraded)',
                     '{earned}/{possible} points (ungraded)',
                     ctx.weighted_max_score
@@ -634,11 +634,11 @@ function DragAndDropTemplates(configuration) {
         // placedholders (as the last content in the bank) to maintain original bank dimensions.
         var bank_children = [];
         items_in_bank.forEach(function(item) {
-          if (item.is_dragged) {
-              bank_children.push(itemPlaceholderTemplate(item, ctx));
-          } else {
-              bank_children.push(itemTemplate(item, ctx));
-          }
+            if (item.is_dragged) {
+                bank_children.push(itemPlaceholderTemplate(item, ctx));
+            } else {
+                bank_children.push(itemTemplate(item, ctx));
+            }
         });
         bank_children = bank_children.concat(renderCollection(itemPlaceholderTemplate, items_placed, ctx));
         var drag_container_style = {};
@@ -716,8 +716,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     var renderView = DragAndDropTemplates(configuration);
 
     var $element = $(element);
-    element = $element[0]; // TODO: This line can be removed when we no longer support Dogwood.
-                           // It works around this Studio bug: https://github.com/edx/edx-platform/pull/11433
+
     // root: root node managed by the virtual DOM
     var $root = $element.find('.xblock--drag-and-drop');
     var root = $root[0];
@@ -725,6 +724,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     var state = undefined;
     var bgImgNaturalWidth = undefined;  // pixel width of the background image (when not scaled)
     var containerMaxWidth = null;  // measured and set after first render
+    var fixedHeaderHeight = 0; // measured in checkForFixedHeader
     var __vdom = virtualDom.h();  // blank virtual DOM
 
     // Event string size limit.
@@ -815,6 +815,8 @@ function DragAndDropBlock(runtime, element, configuration) {
 
             measureWidthAndRender();
 
+            checkForFixedHeader();
+
             initDraggable();
             initDroppable();
 
@@ -861,6 +863,24 @@ function DragAndDropBlock(runtime, element, configuration) {
         // Re-render now that correct max-width is known.
         applyState();
     };
+
+    var checkForFixedHeader = function() {
+        // There might be a fixed header covering the upper part of the screen,
+        // which needs to be taken into account when scrolling while dragging.
+        var windowHeight = $(window).height();
+
+        var topElement = $(document.elementFromPoint(0, 0));
+        if (topElement) {
+            var topElementParents = topElement.parents();
+            for (var i = 0; i < topElementParents.length; i++) {
+                var parent = $(topElementParents[i]);
+                if (parent.css('position') === 'fixed') {
+                    fixedHeaderHeight = parent.height();
+                    break;
+                }
+            }
+        }
+    }
 
     var runOnKey = function(evt, key, handler) {
         if (evt.which === key) {
@@ -933,16 +953,16 @@ function DragAndDropBlock(runtime, element, configuration) {
     };
 
     var preventFauxPopupCloseButtonClick = function(evt) {
-      if (_popup_close_button_keydown_received) {
-          // The close button received a keydown event prior to this keyup,
-          // so this event is genuine.
-          _popup_close_button_keydown_received = false;
-      } else {
-          // There was no keydown prior to this keyup, so the keydown must have happend *before*
-          // the popup was displayed and focused and the keypress is still in progress.
-          // Make the browser ignore this keyup event.
-          evt.preventDefault();
-      }
+        if (_popup_close_button_keydown_received) {
+            // The close button received a keydown event prior to this keyup,
+            // so this event is genuine.
+            _popup_close_button_keydown_received = false;
+        } else {
+            // There was no keydown prior to this keyup, so the keydown must have happend *before*
+            // the popup was displayed and focused and the keypress is still in progress.
+            // Make the browser ignore this keyup event.
+            evt.preventDefault();
+        }
     };
 
     var focusModalButton = function() {
@@ -1388,7 +1408,7 @@ function DragAndDropBlock(runtime, element, configuration) {
             $dragged_items_container.hide();
             var element = document.elementFromPoint(x, y);
             while (element) {
-              if (isValidDropTarget(element)) {
+                if (isValidDropTarget(element)) {
                     $zone = $(element);
                     break;
                 } else {
@@ -1453,8 +1473,46 @@ function DragAndDropBlock(runtime, element, configuration) {
                     cancelAnimationFrame(raf_id);
                 }
                 raf_id = requestAnimationFrame(function() {
-                    var dx = pageX(evt) - drag_origin.x;
-                    var dy = pageY(evt) - drag_origin.y;
+                    var x = pageX(evt);
+                    var y = pageY(evt);
+
+                    var thresholdWidth = 50;
+
+                    var $target = $container.find('.target');
+                    var targetRect = $target.get(0).getBoundingClientRect();
+                    var top = targetRect.top + window.scrollY;
+                    var bottom = targetRect.bottom + window.scrollY;
+                    var left = targetRect.left + window.scrollX - thresholdWidth;
+                    var right = targetRect.right + window.scrollX + thresholdWidth;
+
+                    if (top <= y && bottom >= y && left <= x && right >= x) {
+                        var viewportTop = window.scrollY + fixedHeaderHeight;
+                        var viewportBottom = window.scrollY + $(window).height();
+                        var viewportLeft = window.scrollX;
+                        var viewportRight = window.scrollX + $(window).width();
+
+                        var scrollAmount = 50;
+
+                        if (x < (viewportLeft + thresholdWidth)) {
+                            $target.scrollLeft($target.scrollLeft() - scrollAmount);
+                        }
+
+                        if (x > (viewportRight - thresholdWidth)) {
+                            $target.scrollLeft($target.scrollLeft() + scrollAmount);
+                        }
+
+                        if (y > (viewportBottom - thresholdWidth)) {
+                            $document.scrollTop($document.scrollTop() + scrollAmount);
+                        }
+
+                        if (top < viewportTop + thresholdWidth && y < (viewportTop + thresholdWidth)) {
+                            $document.scrollTop($document.scrollTop() - scrollAmount);
+                        }
+                    }
+
+                    var dx = x - drag_origin.x;
+                    var dy = y - drag_origin.y;
+
                     var left = original_position.left + dx;
                     var top = original_position.top + dy;
                     left = Math.max(0, Math.min(max_left, left));
@@ -1467,7 +1525,7 @@ function DragAndDropBlock(runtime, element, configuration) {
 
             var onDragEnd = function(evt) {
                 if (raf_id) {
-                  cancelAnimationFrame(raf_id);
+                    cancelAnimationFrame(raf_id);
                 }
                 if (evt.type === 'mouseup') {
                     $document.off('mousemove', onDragMove);
@@ -1815,7 +1873,7 @@ function DragAndDropBlock(runtime, element, configuration) {
         // In assessment mode, it is possible to move items back to the bank, so the bank should be able to
         // gain focus while keyboard placement is in progress.
         var item_bank_focusable = (state.keyboard_placement_mode || state.showing_answer) &&
-                configuration.mode === DragAndDropBlock.ASSESSMENT_MODE;
+            configuration.mode === DragAndDropBlock.ASSESSMENT_MODE;
 
         var context = {
             drag_container_max_width: containerMaxWidth,

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -148,6 +148,28 @@ class BaseIntegrationTest(SeleniumBaseTest):
     def scroll_down(self, pixels=50):
         self.browser.execute_script("$(window).scrollTop({})".format(pixels))
 
+    def is_element_in_viewport(self, element):
+        """Determines if the element lies at least partially in the viewport."""
+        viewport = self.browser.execute_script(
+            "return {"
+            "top: window.scrollY,"
+            "left: window.scrollX,"
+            "bottom: window.scrollY + window.outerHeight,"
+            "right: window.scrollX + window.outerWidth"
+            "};"
+        )
+
+        return all([
+            any([
+                viewport["top"] <= element.rect["y"] <= viewport["bottom"],
+                viewport["top"] <= element.rect["y"] + element.rect["height"] <= viewport["bottom"]
+            ]),
+            any([
+                viewport["left"] <= element.rect["x"] <= viewport["right"],
+                viewport["left"] <= element.rect["x"] + element.rect["width"] <= viewport["right"]
+            ])
+        ])
+
     def _get_style(self, selector, style, computed=True):
         if computed:
             query = 'return getComputedStyle($("{selector}").get(0)).{style}'

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -698,3 +698,41 @@ class TestMaxItemsPerZone(InteractionTestBase, BaseIntegrationTest):
         self.assert_placed_item(6, zone_id, assessment_mode=self.assessment_mode)
         self.assert_placed_item(7, zone_id, assessment_mode=self.assessment_mode)
         self.assert_reverted_item(8)
+
+
+class DragScrollingTest(InteractionTestBase, BaseIntegrationTest):
+    """Tests that drop targets are scrolled into view while dragging."""
+
+    PAGE_TITLE = 'Drag and Drop v2'
+    PAGE_ID = 'drag_and_drop_v2'
+
+    def setUp(self):
+        super(DragScrollingTest, self).setUp()
+        self.browser.set_window_size(320, 480)
+
+    def _get_scenario_xml(self):
+        return self._get_custom_scenario_xml("data/test_html_data.json")
+
+    def test_scrolling_during_placement(self):
+        item1_id = 0
+        zone1_id = "zone-1"
+
+        zone2_id = "zone-2"
+
+        zone1 = self._get_zone_by_id(zone1_id)
+        zone2 = self._get_zone_by_id(zone2_id)
+
+        # zone2 is at 0, 0 in the target container, so initially
+        # visible, even with the page header
+        self.assertTrue(self.is_element_in_viewport(zone2))
+
+        # zone 1 is at 100, 200 in its container, so with the page
+        # header, it's initially below the viewport
+        self.assertFalse(self.is_element_in_viewport(zone1))
+
+        # when placing the item in zone1, zone1 will scroll into view
+        self.place_item(item1_id, zone1_id)
+        self.assertTrue(self.is_element_in_viewport(zone1))
+
+        # and now zone2 is out of view
+        self.assertFalse(self.is_element_in_viewport(zone2))


### PR DESCRIPTION
## [MCKIN-6681](https://edx-wiki.atlassian.net/browse/MCKIN-6681)

### Description

If the target image is larger than the screen, scroll the target area as
necessary while dragging to allow the user to reach the drop zone.

When setting up the threshold areas which trigger scrolling, fixed
headers that overlay the top of the image need to be considered, so I've
added a check for those.

Tested on desktop browsers, mobile Safari, Chrome on Android, and iOS
native apps.

### Reviewers
- [ @mtyaka ] Matjaz Gregoric
- [ @bradenmacdonald ] Braden MacDonald

