### PR TITLE
[MCKIN-6965] Newly Added Drag and Drop blocks not loading in Studio

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -803,9 +803,9 @@ function DragAndDropBlock(runtime, element, configuration) {
 
             // For the next one, we need to use addEventListener with useCapture 'true' in order
             // to watch for load events on any child element, since load events do not bubble.
-            element.addEventListener('load', webkitFix, true);
+            $element.get(0).addEventListener('load', webkitFix, true);
             // Whenever the container div resizes, re-render to take new available width into account.
-            element.addEventListener('load', bindContainerResize, true);
+            $element.get(0).addEventListener('load', bindContainerResize, true);
 
             // Re-render when window size changes.
             $(window).on('resize', measureWidthAndRender);

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -298,6 +298,23 @@ class TestDragAndDropRender(BaseIntegrationTest):
             zone_name = zone.find_element_by_css_selector('p.zone-name')
             self.assertNotIn('sr', zone_name.get_attribute('class'))
 
+    def test_element_as_jquery_does_not_break_load_event_listeners(self):
+        """
+        DragAndDropBlock.init should accept a jQuery object or a DOM element.
+
+        Some XBlock initialization routes supply the element argument as a plain DOM element, others pass in a jQuery
+        object. DragAndDropBlock.init should cope with either, instead of throwing a TypeError when trying to call
+        addEventListener on jQuery objects, which would cause an infinite "loading" message when adding the block to a
+        unit in Studio.
+        """
+        self.load_scenario()
+
+        for entry in self.browser.get_log('browser'):
+            self.assertNotEqual(
+                'TypeError: element.addEventListener is not a function',
+                entry['message']
+            )
+
 
 @ddt
 class TestDragAndDropRenderZoneAlign(BaseIntegrationTest):


### PR DESCRIPTION
In the drag and drop block's init function, the element argument should now be a jQuery object. This was causing element.addEventListener to fail when setting up the "load" listeners. Use $element instead.

**Reviewers:**
- [x] @e-kolpakov 
- [ ] @bradenmacdonald 
- [ ] @sanfordstudent 