### PR TITLE
MCKIN-7668: toggle highlight on zones when item is dragged or dropped

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1320,6 +1320,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                         placeGrabbedItem($zone);
                     }
                     releaseGrabbedItems();
+                    $root.find('.drag-container').removeClass('dragging');
                 }
             } else if (isTabKey(evt) && !evt.shiftKey) {
                 // If the user just dropped an item to this zone, next TAB keypress
@@ -1361,6 +1362,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                 state.keyboard_placement_mode = true;
                 grabItem($item, 'keyboard');
                 $selectedItem = $item;
+                $container.addClass('dragging');
                 $root.find('.target .zone').first().focus();
             }
         });
@@ -1437,9 +1439,9 @@ function DragAndDropBlock(runtime, element, configuration) {
                 left: item_offset.left - container_offset.left,
                 top: item_offset.top - container_offset.top
             };
-
             item.drag_position = original_position;
             grabItem($item, 'mouse');
+            $container.addClass('dragging');
 
             // Animate the item back to its original position in the bank.
             var revertDrag = function() {
@@ -1550,6 +1552,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                 } else {
                     revertDrag();
                 }
+                $container.removeClass('dragging');
             };
 
             if (interaction_type === 'mouse') {

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -422,9 +422,17 @@ class InteractionTestBase(object):
         zone.send_keys(action_key)
 
     def assert_item_grabbed(self, item):
+        drag_container = item.find_element_by_xpath(
+            "./ancestor::div[contains(concat(' ', @class, ' '), ' drag-container ')][1]"
+        )
+        self.assertIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'true')
 
     def assert_item_not_grabbed(self, item):
+        drag_container = item.find_element_by_xpath(
+            "./ancestor::div[contains(concat(' ', @class, ' '), ' drag-container ')][1]"
+        )
+        self.assertNotIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
 
     def assert_placed_item(self, item_value, zone_title, assessment_mode=False):

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -422,16 +422,10 @@ class InteractionTestBase(object):
         zone.send_keys(action_key)
 
     def assert_item_grabbed(self, item):
-        drag_container = item.find_element_by_xpath(
-            "./ancestor::div[contains(concat(' ', @class, ' '), ' drag-container ')][1]"
-        )
         self.assertIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'true')
 
     def assert_item_not_grabbed(self, item):
-        drag_container = item.find_element_by_xpath(
-            "./ancestor::div[contains(concat(' ', @class, ' '), ' drag-container ')][1]"
-        )
         self.assertNotIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
 

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -422,11 +422,9 @@ class InteractionTestBase(object):
         zone.send_keys(action_key)
 
     def assert_item_grabbed(self, item):
-        self.assertIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'true')
 
     def assert_item_not_grabbed(self, item):
-        self.assertNotIn("dragging", drag_container.get_attribute('class').split(' '))
         self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
 
     def assert_placed_item(self, item_value, zone_title, assessment_mode=False):

--- a/tests/integration/test_interaction.py
+++ b/tests/integration/test_interaction.py
@@ -402,7 +402,7 @@ class StandardInteractionTest(DefaultDataTestMixin, InteractionTestBase, Paramet
             drag_container = item.find_element_by_xpath(  # get item parent drag container
                 "./ancestor::div[contains(concat(' ', @class, ' '), ' drag-container ')][1]"
             )
-            if 'fade' not in item.get_attribute('class').split(' '): # if item is draggable
+            if 'fade' not in item.get_attribute('class').split(' '):  # if item is draggable
                 item.send_keys(action_key)
                 self.assertIn("dragging", drag_container.get_attribute('class').split(' '))
 


### PR DESCRIPTION
When a user starts dragging an item target zones should appear with green outline and a + sign once a user clicks on a draggable tile or uses keyboard shortcuts to drag a tile. Target zones disappear once draggable item is placed onto target area.
