### PR TITLE
MCKIN-8019: made correction to data type for drop_item val attribute

### DIFF
--- a/Native_API.md
+++ b/Native_API.md
@@ -85,7 +85,7 @@ Contains feedback shown to the user
 #### `drop_item`
 
 This JSON handler is used to handle dropping an item in a zone. The arguments are
-- `val`: (string) The number of the item.
+- `val`: (int) The number of the item.
 - `zone`: (string) The uid of the zone.
 
 In assessment mode will return an empty object, while in standard mode it returns the following:


### PR DESCRIPTION
https://edx-wiki.atlassian.net/browse/MCKIN-8019
Passing `String` value in `val` attribute of `drop_item` results in error. This PR updates document to reflect correct datatype.