### PR TITLE
Image error event temporary fix

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1023,7 +1023,8 @@ function DragAndDropBlock(runtime, element, configuration) {
                 promise.reject();
             }
         }, false);
-        img.addEventListener("error", function() { promise.reject(); });
+        /* ToDo: To fix, temporarily commenting out to prevent chrome/safari error on borken images */
+        /* img.addEventListener("error", function() { promise.reject(); }); */
         img.src = configuration.target_img_expanded_url;
         img.alt = configuration.target_img_description;
         return promise;


### PR DESCRIPTION
Ticket: https://edx-wiki.atlassian.net/browse/MCKIN-8249

On QA/Stage environments, background images are somehow being requested twice. 1st attempt goes successful, while on 2nd, a broken image URL is attempted, which causes exception on chrome/safari and webviews do not load. 
This is a temporary fix to get deployment going, we'll get back to it to investigate and do a permanent fix.