### PR TITLE
Show answer hidden when attempts remaining in assess mode MCKIN-8615

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -541,7 +541,7 @@ function DragAndDropTemplates(configuration) {
 
     var sidebarTemplate = function(ctx) {
         var showAnswerButton = null;
-        if (ctx.show_show_answer) {
+        if (ctx.show_show_answer && !ctx.disable_show_answer_button) {
             var options = {
                 disabled: ctx.showing_answer ? true : ctx.disable_show_answer_button,
                 spinner: ctx.show_answer_spinner

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -540,9 +540,7 @@ function DragAndDropTemplates(configuration) {
     };
 
     var sidebarTemplate = function(ctx) {
-        var showAnswerButton = sidebarButtonTemplate(
-            "show-answer-button sr"
-        );
+        var showAnswerButton = null;
         if (ctx.show_show_answer && !ctx.disable_show_answer_button) {
             var options = {
                 disabled: ctx.showing_answer,

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -541,11 +541,11 @@ function DragAndDropTemplates(configuration) {
 
     var sidebarTemplate = function(ctx) {
         var showAnswerButton = sidebarButtonTemplate(
-                "show-answer-button sr"
-            );
+            "show-answer-button sr"
+        );
         if (ctx.show_show_answer && !ctx.disable_show_answer_button) {
             var options = {
-                disabled: ctx.showing_answer ? true : ctx.disable_show_answer_button,
+                disabled: ctx.showing_answer,
                 spinner: ctx.show_answer_spinner
             };
             showAnswerButton = sidebarButtonTemplate(

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -540,7 +540,9 @@ function DragAndDropTemplates(configuration) {
     };
 
     var sidebarTemplate = function(ctx) {
-        var showAnswerButton = null;
+        var showAnswerButton = sidebarButtonTemplate(
+                "show-answer-button sr"
+            );
         if (ctx.show_show_answer && !ctx.disable_show_answer_button) {
             var options = {
                 disabled: ctx.showing_answer ? true : ctx.disable_show_answer_button,

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -247,11 +247,14 @@ class AssessmentInteractionTest(
         attempts are remaining, hidden otherwise. It is disabled and displays
         correct answers when clicked
         """
-        self.assertRaises(self._get_show_answer_button())
+        show_answer_button = self._get_show_answer_button()
+
+        # Class sr indicates the button is hidden
+        self.assertIn('sr', show_answer_button.get_attribute('class').split())
 
         self.place_item(0, TOP_ZONE_ID, Keys.RETURN)
         for _ in xrange(self.MAX_ATTEMPTS-1):
-            self.assertRaises(self._get_show_answer_button())
+            self.assertIn('sr', show_answer_button.get_attribute('class').split())
             self.click_submit()
 
         # Place an incorrect item on the final attempt.
@@ -262,12 +265,14 @@ class AssessmentInteractionTest(
         popup = self._get_popup()
         self.assertTrue(popup.is_displayed())
 
-        show_answer_button = self._get_show_answer_button()
-        self.assertIsNotNone(show_answer_button)
+        # Absence of class sr indicates button is shown
+        self.assertNotIn('sr', show_answer_button.get_attribute('class').split())
+
+        # The button should be enabled when shown
         self.assertIsNone(show_answer_button.get_attribute('disabled'))
         self.click_show_answer()
 
-         # The popup should be closed upon clicking Show Answer.
+        # The popup should be closed upon clicking Show Answer.
         self.assertFalse(popup.is_displayed())
 
         self.assertEqual(show_answer_button.get_attribute('disabled'), 'true')

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -219,6 +219,60 @@ class AssessmentInteractionTest(
         self.assertEqual(submit_button.get_attribute('disabled'), 'true')
         self.assertEqual(reset_button.get_attribute('disabled'), 'true')
 
+    def _assert_show_answer_item_placement(self):
+        zones = dict(self.all_zones)
+        for item in self._get_items_with_zone(self.items_map).values():
+            zone_titles = [zones[zone_id] for zone_id in item.zone_ids]
+            # When showing answers, correct items are placed as if assessment_mode=False
+            self.assert_placed_item(item.item_id, zone_titles, assessment_mode=False)
+
+        for item_definition in self._get_items_without_zone(self.items_map).values():
+            self.assertNotDraggable(item_definition.item_id)
+            item = self._get_item_by_value(item_definition.item_id)
+            self.assertEqual(item.get_attribute('aria-grabbed'), 'false')
+            self.assertEqual(item.get_attribute('class'), 'option fade')
+
+            item_content = item.find_element_by_css_selector('.item-content')
+            self.assertEqual(item_content.get_attribute('aria-describedby'), None)
+
+            try:
+                item.find_element_by_css_selector('.sr.description')
+                self.fail("Description element should not be present")
+            except NoSuchElementException:
+                pass
+
+    def test_show_answer(self):
+        """
+        Test "Show Answer" button is shown in assessment mode only when no more
+        attempts are remaining, hidden otherwise. It is disabled and displays
+        correct answers when clicked
+        """
+        show_answer_button = self._get_show_answer_button()
+        self.assertIsNone(show_answer_button)
+
+        self.place_item(0, TOP_ZONE_ID, Keys.RETURN)
+        for _ in xrange(self.MAX_ATTEMPTS-1):
+            self.assertIsNone(show_answer_button)
+            self.click_submit()
+
+        # Place an incorrect item on the final attempt.
+        self.place_item(1, TOP_ZONE_ID, Keys.RETURN)
+        self.click_submit()
+
+        # A feedback popup should open upon final submission.
+        popup = self._get_popup()
+        self.assertTrue(popup.is_displayed())
+
+        self.assertIsNotNone(show_answer_button)
+        self.assertIsNone(show_answer_button.get_attribute('disabled'))
+        self.click_show_answer()
+
+         # The popup should be closed upon clicking Show Answer.
+        self.assertFalse(popup.is_displayed())
+
+        self.assertEqual(show_answer_button.get_attribute('disabled'), 'true')
+        self._assert_show_answer_item_placement()
+
     def test_do_attempt_feedback_is_updated(self):
         """
         Test updating overall feedback after submitting solution in assessment mode

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -247,12 +247,11 @@ class AssessmentInteractionTest(
         attempts are remaining, hidden otherwise. It is disabled and displays
         correct answers when clicked
         """
-        show_answer_button = self._get_show_answer_button()
-        self.assertIsNone(show_answer_button)
+        self.assertRaises(self._get_show_answer_button())
 
         self.place_item(0, TOP_ZONE_ID, Keys.RETURN)
         for _ in xrange(self.MAX_ATTEMPTS-1):
-            self.assertIsNone(show_answer_button)
+            self.assertRaises(self._get_show_answer_button())
             self.click_submit()
 
         # Place an incorrect item on the final attempt.
@@ -263,6 +262,7 @@ class AssessmentInteractionTest(
         popup = self._get_popup()
         self.assertTrue(popup.is_displayed())
 
+        show_answer_button = self._get_show_answer_button()
         self.assertIsNotNone(show_answer_button)
         self.assertIsNone(show_answer_button.get_attribute('disabled'))
         self.click_show_answer()

--- a/tests/integration/test_interaction_assessment.py
+++ b/tests/integration/test_interaction_assessment.py
@@ -243,18 +243,12 @@ class AssessmentInteractionTest(
 
     def test_show_answer(self):
         """
-        Test "Show Answer" button is shown in assessment mode only when no more
-        attempts are remaining, hidden otherwise. It is disabled and displays
-        correct answers when clicked
+        Test "Show Answer" button is shown in assessment mode when no more
+        attempts are remaining. It is disabled and displays correct
+        answers when clicked
         """
-        show_answer_button = self._get_show_answer_button()
-
-        # Class sr indicates the button is hidden
-        self.assertIn('sr', show_answer_button.get_attribute('class').split())
-
         self.place_item(0, TOP_ZONE_ID, Keys.RETURN)
         for _ in xrange(self.MAX_ATTEMPTS-1):
-            self.assertIn('sr', show_answer_button.get_attribute('class').split())
             self.click_submit()
 
         # Place an incorrect item on the final attempt.
@@ -265,8 +259,7 @@ class AssessmentInteractionTest(
         popup = self._get_popup()
         self.assertTrue(popup.is_displayed())
 
-        # Absence of class sr indicates button is shown
-        self.assertNotIn('sr', show_answer_button.get_attribute('class').split())
+        show_answer_button = self._get_show_answer_button()
 
         # The button should be enabled when shown
         self.assertIsNone(show_answer_button.get_attribute('disabled'))


### PR DESCRIPTION
As a learner using drag and drop on desktop, i only want the show answer button to appear when i have used all of my attempts in assessment mode so I i know what the correct answer is.

Acceptance Criteria
-the Show Answer button should not be visible or greyed out in the frame
-It should be prominently displayed and clickable only when a user has no more attempts left

Reference: https://edx-wiki.atlassian.net/browse/MCKIN-8615
