### PR TITLE
Show Answer button for fixed sizing in Assessment mode 8594

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -2186,8 +2186,7 @@ function DragAndDropBlock(runtime, element, configuration) {
             problem_html: configuration.problem_text,
             show_problem_header: configuration.show_problem_header,
             show_submit_answer: configuration.mode == DragAndDropBlock.ASSESSMENT_MODE,
-            show_show_answer: (configuration.mode == DragAndDropBlock.ASSESSMENT_MODE && 
-                configuration.item_sizing == DragAndDropBlock.FREE_SIZING),
+            show_show_answer: (configuration.mode == DragAndDropBlock.ASSESSMENT_MODE ),
             show_feedback_bar: canShowFeedbackBar(),
             target_img_src: configuration.target_img_expanded_url,
             target_img_description: configuration.target_img_description,


### PR DESCRIPTION
Change to check: Show answer button is now visible for fixed sizing in Assessment mode as previously shown in free sizing.

Screen shots of the UI before and after the change are attached.
Steps to reproduce:
1) Use all attempts in Fixed sizing, Assessment mode.
2) Refresh the page.

Screen shot before:
![before](https://user-images.githubusercontent.com/17109504/47162587-a7ea8400-d30d-11e8-8fea-b1c1e77df30a.png)
Screen shot after:
![after](https://user-images.githubusercontent.com/17109504/47162586-a7ea8400-d30d-11e8-8961-f2441d3e5393.png)

Please find detailed description on the ticket below:
https://edx-wiki.atlassian.net/browse/MCKIN-8594