### PR TITLE
MCKIN-10393 Fix bug affecting dragging on mobile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
     - "pip install selenium==2.53.0"
     - "pip uninstall -y xblock-drag-and-drop-v2"
     - "python setup.py sdist"
-    - "pip install dist/xblock-drag-and-drop-v2-2.2.0.tar.gz"
+    - "pip install dist/xblock-drag-and-drop-v2-2.2.1.tar.gz"
 script:
     - pep8 drag_and_drop_v2 tests --max-line-length=120
     - pylint drag_and_drop_v2

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1451,8 +1451,9 @@ function DragAndDropBlock(runtime, element, configuration) {
                 item_id: item_id
             });
 
-            var max_left = $container.innerWidth() - $item.outerWidth();
-            var max_top = $container.innerHeight() - $item.outerHeight();
+            var container_width = $container.innerWidth();
+            var container_height = $container.innerHeight();
+
             // We need to get the item position relative to the $container.
             var item_offset = $item.offset();
             var container_offset = $container.offset();
@@ -1536,11 +1537,16 @@ function DragAndDropBlock(runtime, element, configuration) {
                     var dx = x - drag_origin.x;
                     var dy = y - drag_origin.y;
 
+                    if (typeof item.max_left === 'undefined') {
+                        var $draggedItem = $container.find('.option[data-value=' + item_id + ']');
+                        item.max_left =  container_width - $draggedItem.outerWidth();
+                        item.max_top = container_height - $draggedItem.outerHeight();
+                    }
                     var left = original_position.left + dx;
                     var top = original_position.top + dy;
-                    left = Math.max(0, Math.min(max_left, left));
-                    top = Math.max(0, Math.min(max_top, top));
-                    item.drag_position = {left: left, top: top};
+                    left = Math.max(0, Math.min(item.max_left, left));
+                    top = Math.max(0, Math.min(item.max_top, top));
+                    item.drag_position = {left: left, top: top};;
                     applyState();
                     raf_id = null;
                 });

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.2.0',
+    version='2.2.1',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
When having a large draggable item the limits are not calculated correctly and the xblock doesn't let the user to drag the item all the way to the right. This happens because the limit is calculated once when the drag is [initiated](https://github.com/edx-solutions/xblock-drag-and-drop-v2/blob/master/drag_and_drop_v2/public/js/drag_and_drop.js#L1465). But when the item is moved the actual div that gets moved is a different one created when an item is marked as [dragged](https://github.com/edx-solutions/xblock-drag-and-drop-v2/blob/master/drag_and_drop_v2/public/js/drag_and_drop.js#L175) and a different [style](https://github.com/edx-solutions/xblock-drag-and-drop-v2/blob/122da26ee82dc4f4873e2172b0a618c50a5883c4/drag_and_drop_v2/public/css/drag_and_drop.css#L112) is applied to it making the width only 30% of the original. This makes the limit be wrong. The solution is to calculate the limits by using the actual div that's being dragged.
This PR calculates the limits correctly and it only does it once by using a sort of memoization for performance.

**Screenshots**: 
Wrong limits calculated in mobile view
![dnd-before](https://user-images.githubusercontent.com/4007280/55522878-672cc000-564c-11e9-9104-7caeb0c5c284.gif)

Behavior with the updates in this PR
![dnd-after](https://user-images.githubusercontent.com/4007280/55522919-80ce0780-564c-11e9-8b53-9a00c2acb1f3.gif)

**Testing instructions**:

1. Crate a Drag and Drop problem.
2. Add an item with large text.
3. Try dragging the item using a mobile view.