### PR TITLE
[MCKIN-10516] Reduce drag delay on mobile

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -758,7 +758,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     // Number of miliseconds the user has to keep their finger on the item
     // without moving for drag to begin.
     // This allows user to scroll the container without accidentally dragging the items.
-    var TOUCH_DRAG_DELAY = 500;
+    var TOUCH_DRAG_DELAY = 250;
 
     // Keyboard accessibility
     var ESC = 27;


### PR DESCRIPTION
We received feedback that moving items is not intuitive on touch devices. After the QA we determined that increasing sensitivity of dragging items (reducing the dragging delay) improves user experience here. This way it is less unusual for user to wait after holding his finger on the item:
![sensitivity](https://user-images.githubusercontent.com/3189670/57473401-0a967380-7290-11e9-961b-6a729526433e.gif)

# Testing instructions:
1. Create a drag & drop xblock.
2. Visit the course as student on mobile device or use browser dev tools to change site resolution.
3. Check that the drag & drop delay is reduced.