### PR TITLE
[MCKIN-10994] Move items around their centers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+dist: xenial
+services:
+    - xvfb
 sudo: false
 python:
     - "2.7"

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -135,6 +135,10 @@
         overflow-x: auto;
     }
 
+    .xblock--drag-and-drop .drag-container .option {
+        max-width: 80%;
+    }
+
     .xblock--drag-and-drop .drag-container .item-bank .option {
         flex-shrink: 0;
         flex-grow: 0;

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -106,8 +106,10 @@ function DragAndDropTemplates(configuration) {
         }
         if (item.is_dragged) {
             style.position = 'absolute';
-            style.left = item.drag_position.left + 'px';
-            style.top = item.drag_position.top + 'px';
+            var left = Math.max(0, Math.min(item.max_left, item.drag_position.left));
+            var top = Math.max(0, Math.min(item.max_top, item.drag_position.top));
+            style.left = left + 'px';
+            style.top = top + 'px';
         }
         if (item.is_placed) {
             var maxWidth = (item.widthPercent || 30) / 100;
@@ -1470,12 +1472,21 @@ function DragAndDropBlock(runtime, element, configuration) {
             // We need to get the item position relative to the $container.
             var item_offset = $item.offset();
             var container_offset = $container.offset();
-            var original_position = {
-                left: item_offset.left - container_offset.left,
-                top: item_offset.top - container_offset.top
+
+            // We need to drag the item by its center.
+            var mid_position = {
+                x: item_offset.left + $item.innerWidth() / 2,
+                y: item_offset.top + $item.innerHeight() / 2
             };
 
-            item.drag_position = original_position;
+            var centered_position = {
+                left: item_offset.left - container_offset.left + (drag_origin.x - mid_position.x),
+                top: item_offset.top - container_offset.top + (drag_origin.y - mid_position.y)
+            };
+
+            item.max_left =  container_width - $item.outerWidth();
+            item.max_top = container_height - $item.outerHeight();
+            item.drag_position = centered_position;
             grabItem($item, 'mouse');
 
             // Animate the item back to its original position in the bank.
@@ -1489,8 +1500,8 @@ function DragAndDropBlock(runtime, element, configuration) {
                     }
                     var progress = Math.min(1, (ts - start_ts) / revert_duration);
                     item.drag_position = {
-                        left: start_position.left + (progress * (original_position.left - start_position.left)),
-                        top: start_position.top + (progress * (original_position.top - start_position.top)),
+                        left: start_position.left + (progress * (centered_position.left - start_position.left)),
+                        top: start_position.top + (progress * (centered_position.top - start_position.top)),
                     };
                     if (progress === 1) {
                         delete item.drag_position;
@@ -1549,17 +1560,11 @@ function DragAndDropBlock(runtime, element, configuration) {
 
                     var dx = x - drag_origin.x;
                     var dy = y - drag_origin.y;
-
-                    if (typeof item.max_left === 'undefined') {
-                        var $draggedItem = $container.find('.option[data-value=' + item_id + ']');
-                        item.max_left =  container_width - $draggedItem.outerWidth();
-                        item.max_top = container_height - $draggedItem.outerHeight();
-                    }
-                    var left = original_position.left + dx;
-                    var top = original_position.top + dy;
-                    left = Math.max(0, Math.min(item.max_left, left));
-                    top = Math.max(0, Math.min(item.max_top, top));
-                    item.drag_position = {left: left, top: top};;
+                    var next_left = centered_position.left + dx;
+                    var next_top = centered_position.top + dy;
+                    next_left = Math.max(0, Math.min(item.max_left, next_left));
+                    next_top = Math.max(0, Math.min(item.max_top, next_top));
+                    item.drag_position = {left: next_left, top: next_top};
                     applyState();
                     raf_id = null;
                 });
@@ -1899,6 +1904,8 @@ function DragAndDropBlock(runtime, element, configuration) {
                 grabbed_with: item.grabbed_with,
                 is_dragged: Boolean(item.drag_position),
                 drag_position: item.drag_position,
+                max_left: item.max_left,
+                max_top: item.max_top,
                 is_placed: Boolean(item_user_state),
                 widthPercent: item.widthPercent, // widthPercent may be undefined (auto width)
                 imgNaturalWidth: item.imgNaturalWidth,


### PR DESCRIPTION
This makes dragging items more natural on mobile by disabling their shrinking and dragging them around their centers.

![center](https://user-images.githubusercontent.com/3189670/58445133-ad0d7e00-80fb-11e9-931a-d89534497cb6.gif)

## Testing instructions
1. Create course with D&D XBlock.
1. Check the unit using PC and mobile resolutions.

## Sandbox
There's a [sandbox with a course setup to test the XBlock](https://dndv2-pr211.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+23+2020/about).