### PR TITLE
[MCKIN-10994] Move items around their centers

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -135,6 +135,10 @@
         overflow-x: auto;
     }
 
+    .xblock--drag-and-drop .drag-container .option {
+        max-width: 80%;
+    }
+
     .xblock--drag-and-drop .drag-container .item-bank .option {
         flex-shrink: 0;
         flex-grow: 0;


### PR DESCRIPTION
This makes dragging items more natural on mobile by disabling their shrinking and dragging them around their centers.

![center](https://user-images.githubusercontent.com/3189670/58445133-ad0d7e00-80fb-11e9-931a-d89534497cb6.gif)

## Testing instructions
1. Create course with D&D XBlock.
1. Check the unit using PC and mobile resolutions.