### PR TITLE
add subsection due date check for DnD Xblock

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -1073,19 +1073,17 @@ class DragAndDropBlock(
         Return the date submissions should be closed from.
 
         Calculates and return the due date after which the submissions
-        will no longer be accepted. Returns None for the AttributeError
-        which happens for pure DragAndDropXblock as due date & graceperiod
-        are not its attributes. They are present for DragAndDropXblockWithMixins
+        will no longer be accepted. Returns None if both due & graceperiod
+        are missing which happens for pure DragAndDropXblock as they are
+        not its attributes. They are present for DragAndDropXblockWithMixins
         """
-        try:
-            due_date = self.due
-
-            if self.graceperiod is not None and due_date:
-                return due_date + self.graceperiod
+        if hasattr(self, 'due') and hasattr(self, 'graceperiod'):
+            due_date = self.due            # pylint: disable=no-member
+            if self.graceperiod is not None and due_date:          # pylint: disable=no-member
+                return due_date + self.graceperiod                 # pylint: disable=no-member
             else:
                 return due_date
-
-        except AttributeError:
+        else:
             return None
 
     def is_self_paced(self):
@@ -1093,15 +1091,14 @@ class DragAndDropBlock(
         Returns if the course is self-paced or not.
 
         Returns the boolean indicating if the parent course is
-        self-paced or not. Returns False for the AttributeError
+        self-paced or not. Returns False if the attribute is missing
         which happens for pure DragAndDropXblock. self_paced attribute is
         present only for DragAndDropXblockWithMixins.
         """
-        try:
-            return self.self_paced
-        except AttributeError:
+        if hasattr(self, 'self_paced'):
+            return self.self_paced           # pylint: disable=no-member
+        else:
             return False
-
 
     @staticmethod
     def workbench_scenarios():

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -356,7 +356,7 @@ class DragAndDropBlock(
             "item_background_color": self.item_background_color or None,
             "item_text_color": self.item_text_color or None,
             "due": self.calculate_due_date(),
-            "self_paced":self.self_paced,
+            "self_paced": self.is_self_paced(),
             # final feedback (data.feedback.finish) is not included - it may give away answers.
         }
 
@@ -1071,13 +1071,37 @@ class DragAndDropBlock(
     def calculate_due_date(self):
         """
         Return the date submissions should be closed from.
-        """
-        due_date = self.due
 
-        if self.graceperiod is not None and due_date:
-            return due_date + self.graceperiod
-        else:
-            return due_date
+        Calculates and return the due date after which the submissions
+        will no longer be accepted. Returns None for the AttributeError
+        which happens for pure DragAndDropXblock as due date & graceperiod
+        are not its attributes. They are present for DragAndDropXblockWithMixins
+        """
+        try:
+            due_date = self.due
+
+            if self.graceperiod is not None and due_date:
+                return due_date + self.graceperiod
+            else:
+                return due_date
+
+        except AttributeError:
+            return None
+
+    def is_self_paced(self):
+        """
+        Returns if the course is self-paced or not.
+
+        Returns the boolean indicating if the parent course is
+        self-paced or not. Returns False for the AttributeError
+        which happens for pure DragAndDropXblock. self_paced attribute is
+        present only for DragAndDropXblockWithMixins.
+        """
+        try:
+            return self.self_paced
+        except AttributeError:
+            return False
+
 
     @staticmethod
     def workbench_scenarios():

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -355,6 +355,8 @@ class DragAndDropBlock(
             "target_img_description": self.target_img_description,
             "item_background_color": self.item_background_color or None,
             "item_text_color": self.item_text_color or None,
+            "due": self.calculate_due_date(),
+            "self_paced":self.self_paced,
             # final feedback (data.feedback.finish) is not included - it may give away answers.
         }
 
@@ -1065,6 +1067,17 @@ class DragAndDropBlock(
             bool: True if current answer is correct
         """
         return self._answer_correctness() == self.SOLUTION_CORRECT
+
+    def calculate_due_date(self):
+        """
+        Return the date submissions should be closed from.
+        """
+        due_date = self.due
+
+        if self.graceperiod is not None and due_date:
+            return due_date + self.graceperiod
+        else:
+            return due_date
 
     @staticmethod
     def workbench_scenarios():

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1855,12 +1855,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     };
 
     var problemNotDue = function () {
-        if(configuration.self_paced || configuration.due===null){
-            return true;
-        }
-        var now = new Date();
-        var due_date = new Date(configuration.due);
-        return (now.getTime() < due_date.getTime());
+        return !configuration.has_deadline_passed;
     };
 
     var submittingLocation = function() {
@@ -1943,8 +1938,6 @@ function DragAndDropBlock(runtime, element, configuration) {
             display_zone_labels: configuration.display_zone_labels,
             display_zone_borders: configuration.display_zone_borders,
             zones: configuration.zones,
-            due: configuration.due,
-            self_paced: configuration.self_paced,
             items: items,
             // state - parts that can change:
             attempts: state.attempts,

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1827,7 +1827,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     };
 
     var canSubmitAttempt = function() {
-        return Object.keys(state.items).length > 0 && attemptsRemain() && !submittingLocation();
+        return Object.keys(state.items).length > 0 && problemNotDue() && attemptsRemain() && !submittingLocation();
     };
 
     var canReset = function() {
@@ -1852,6 +1852,15 @@ function DragAndDropBlock(runtime, element, configuration) {
 
     var attemptsRemain = function() {
         return !configuration.max_attempts || configuration.max_attempts > state.attempts;
+    };
+
+    var problemNotDue = function () {
+        if(configuration.self_paced || configuration.due===null){
+            return true;
+        }
+        var now = new Date();
+        var due_date = new Date(configuration.due);
+        return (now.getTime() < due_date.getTime());
     };
 
     var submittingLocation = function() {
@@ -1934,6 +1943,8 @@ function DragAndDropBlock(runtime, element, configuration) {
             display_zone_labels: configuration.display_zone_labels,
             display_zone_borders: configuration.display_zone_borders,
             zones: configuration.zones,
+            due: configuration.due,
+            self_paced: configuration.self_paced,
             items: items,
             // state - parts that can change:
             attempts: state.attempts,

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -19,6 +19,8 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": null,
+    "due": null,
+    "self_paced": false,
 
     "zones": [
         {

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -19,8 +19,7 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": null,
-    "due": null,
-    "self_paced": false,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -19,8 +19,7 @@
     "display_zone_labels": false,
     "url_name": "unique_name",
     "max_items_per_zone": null,
-    "due": null,
-    "self_paced": false,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -19,6 +19,8 @@
     "display_zone_labels": false,
     "url_name": "unique_name",
     "max_items_per_zone": null,
+    "due": null,
+    "self_paced": false,
 
     "zones": [
         {

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -19,8 +19,7 @@
     "display_zone_labels": false,
     "url_name": "",
     "max_items_per_zone": null,
-    "due": null,
-    "self_paced": false,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -19,6 +19,8 @@
     "display_zone_labels": false,
     "url_name": "",
     "max_items_per_zone": null,
+    "due": null,
+    "self_paced": false,
 
     "zones": [
         {

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -19,6 +19,8 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": 4,
+    "due": null,
+    "self_paced": false,
 
     "zones": [
         {

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -19,8 +19,7 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": 4,
-    "due": null,
-    "self_paced": false,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -77,6 +77,8 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             "item_background_color": None,
             "item_text_color": None,
             "url_name": "",
+            "due": None,
+            "self_paced": False
         })
         self.assertEqual(zones, DEFAULT_DATA["zones"])
         # Items should contain no answer data:

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -77,8 +77,7 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             "item_background_color": None,
             "item_text_color": None,
             "url_name": "",
-            "due": None,
-            "self_paced": False
+            "has_deadline_passed": False,
         })
         self.assertEqual(zones, DEFAULT_DATA["zones"])
         # Items should contain no answer data:

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -297,5 +297,3 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
         """
         self.add_submission_deadline_information(due_date, graceperiod, self_paced)
         self.assertEqual(is_submission_due, self.block.student_view_data()['has_deadline_passed'])
-
-


### PR DESCRIPTION
### [EDUCATOR-965](https://openedx.atlassian.net/browse/EDUCATOR-965)

### Description
Drag & Drop is one of the important problem types that are in use in edx-platform. Despite it being an essential part of the platform, some important features are still missing from it. One of such features is subsection due date check for the Assessment mode. For an instructor-paced course, a DnD problem with Assessment mode can accept submissions after the subsection, in which the DnD problem exists, has passed its due date. This poses a problem importantly in the cases when the DnD problem is part of an exam and the submissions made after the exam has passed can alter the grades. Such incidents consequentially decrease the trust of the course teams in this problem type. This PR adds the due dates checks to avoid submissions after the due date.

### Problem Resolution
To make the decision for enabling/disabling submit button with correspondence to the pacing and due date, the following pieces of information were required:

- Subsection due date
- Course Pacing
- Grace period

None of these fields is available in **DragAndDropXblock**. The first notion was to add these fields directly in the Xblock and have them populated when the problem will be created on the Studio. This, however, was a risky move since all the DnD problems in the production would have been affected by the added fields and would have required a re-publish to get populated with the correct data. For the context, the following is an example of how a DnD problem is stored in the mongo:

`{ "_id" : ObjectId("5bf266a6fdf956134ac2565e"), "fields" : { "data" : { "zones" : [ { "uid" : "top", "title" : "The Top Zone", "align" : "center", "height" : 178, "width" : 196, "y" : 30, "x" : 160, "description" : "Use this zone to associate an item with the top layer of the triangle." }, { "uid" : "middle", "title" : "The Middle Zone", "align" : "center", "height" : 138, "width" : 340, "y" : 210, "x" : 86, "description" : "Use this zone to associate an item with the middle layer of the triangle." }, { "uid" : "bottom", "title" : "The Bottom Zone", "align" : "center", "height" : 135, "width" : 485, "y" : 350, "x" : 15, "description" : "Use this zone to associate an item with the bottom layer of the triangle." } ], "items" : [ { "displayName" : "Goes to the top", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Top Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "top" ], "id" : 0 }, { "displayName" : "Goes to the middle", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Middle Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "middle" ], "id" : 1 }, { "displayName" : "Goes to the bottom", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Bottom Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "bottom" ], "id" : 2 }, { "displayName" : "Goes anywhere", "feedback" : { "incorrect" : "", "correct" : "Of course it goes here! It goes anywhere!" }, "imageURL" : "", "imageDescription" : "", "zones" : [ "top", "middle", "bottom" ], "id" : 3 }, { "displayName" : "I don't belong anywhere", "feedback" : { "incorrect" : "You silly, there are no zones for this one.", "correct" : "" }, "imageURL" : "", "imageDescription" : "", "zones" : [ ], "id" : 4 } ], "targetImgDescription" : "An isosceles triangle with three layers of similar height. It is shown upright, so the widest layer is located at the bottom, and the narrowest layer is located at the top.", "feedback" : { "start" : "Drag the items onto the image above.", "finish" : "Good work! You have completed this drag and drop problem." }, "targetImg" : "/xblock/resource/drag-and-drop-v2/public/img/triangle.png" } }, "edit_info" : { "edited_on" : ISODate("2018-11-19T07:30:46.050Z"), "edited_by" : 2, "original_version" : ObjectId("5bf26695fdf956134ac2565c"), "previous_version" : ObjectId("5bf26695fdf956134ac2565c") }, "block_type" : "drag-and-drop-v2", "schema_version" : 1 }`

This was intriguing as if a DnD problem was viewed from **Staff Debug Info** on the LMS, it showed the information about the due date, pacing and grace period. This led to viewing how the other problems are stored in the mongo. Here is an example of a random problem stored in the Mongo:

`{ "_id" : ObjectId("5c0625a6fdf9560726d4681b"), "fields" : { "data" : "<problem>\n  <multiplechoiceresponse>\n    <label>Which of these statements about rods and cones is true?</label>\n    <choicegroup type="MultipleChoice">\n      <choice correct="true">Rods respond best in a dimly lit environment.</choice>\n      <choice correct="false">Rods are for high light conditions; cones are for low light conditions.</choice>\n      <choice correct="false">The human retina has more cones than rods.</choice>\n      <choice correct="false">Rods come in three types: S, M, and L.</choice>\n    </choicegroup>\n    <solution>\n      <div class="detailed-solution">\n        <p>Explanation</p>\n        <p>Rods respond best in dim light, whereas cones respond best in bright light and to color. There are around 20 times more rods in the retina than there are cones. Cones come in three flavors: S, M, and L.</p>\n      </div>\n    </solution>\n  </multiplechoiceresponse>\n</problem>\n" }, "edit_info" : { "edited_on" : ISODate("2018-12-04T06:58:46.981Z"), "edited_by" : NumberLong(2), "original_version" : ObjectId("5c0625a6fdf9560726d4681b"), "previous_version" : null }, "block_type" : "problem", "schema_version" : 1 }`

As evident from the data, the regular problem types also don't save the due date, pacing and grace period information. This information is embedded at the run time through the help of Mixins. Looking at the DnD xblock created on the studio/LMS side, it is not **DragAndDropXblock**, but **DragAndDropXblockWithMixins**. The xblock created by the studio contained all the necessary information. Based on this information, the idea of adding new fields in the DnDXblock was dropped as this would duplicate the information. The fix in this PR relies on the information coming from the Mixins and no data duplication will happen. 

### Test
 - [ ] Integration tests
 - [x] Unit Tests

### Reviewers


### Post Review
 - [ ] Squash & Rebase commits