### PR TITLE
use submission deadline methods to add subsection due check in DnD

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.2.4 (2019-07-30)
+---------------------------
+
+* Use InheritanceMixin for submission deadline checks (PR #219)
+* Submit button behavior will change in Assessment Mode and will now be impacted by subsection due date, grace period and course pacing
+
 Version 2.2.3 (2019-04-05)
 ---------------------------
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1827,7 +1827,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     };
 
     var canSubmitAttempt = function() {
-        return Object.keys(state.items).length > 0 && attemptsRemain() && !submittingLocation();
+        return Object.keys(state.items).length > 0 && isPastDue() && attemptsRemain() && !submittingLocation();
     };
 
     var canReset = function() {
@@ -1844,6 +1844,10 @@ function DragAndDropBlock(runtime, element, configuration) {
             }
         }
         return any_items_placed && (configuration.mode !== DragAndDropBlock.ASSESSMENT_MODE || attemptsRemain());
+    };
+
+    var isPastDue = function () {
+        return !configuration.has_deadline_passed;
     };
 
     var canShowAnswer = function() {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.2.3',
+    version='2.2.4',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -19,6 +19,7 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": null,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -19,7 +19,7 @@
     "display_zone_labels": false,
     "url_name": "unique_name",
     "max_items_per_zone": null,
-
+    "has_deadline_passed": false,
     "zones": [
         {
           "title": "Zone <i>1</i>",

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -19,6 +19,7 @@
     "display_zone_labels": false,
     "url_name": "",
     "max_items_per_zone": null,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -19,6 +19,7 @@
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": 4,
+    "has_deadline_passed": false,
 
     "zones": [
         {

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -77,6 +77,7 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             "item_background_color": None,
             "item_text_color": None,
             "url_name": "",
+            "has_deadline_passed": False,
         })
         self.assertEqual(zones, DEFAULT_DATA["zones"])
         # Items should contain no answer data:


### PR DESCRIPTION
### [EDUCATOR - 4521](https://openedx.atlassian.net/browse/EDUCATOR-4521)

### Description
Drag & Drop is one of the important problem types that are in use in edx-platform. Despite it being an essential part of the platform, some important features are still missing from it. One of such features is subsection due date check for the Assessment mode. For an instructor-paced course, a DnD problem with Assessment mode can accept submissions after the subsection, in which the DnD problem exists, has passed its due date. This poses a problem importantly in the cases when the DnD problem is part of an exam and the submissions made after the exam has passed can alter the grades. Such incidents consequentially decrease the trust of the course teams in this problem type. This PR adds the due dates checks to avoid submissions after the due date.

### Problem Resolution
To make the decision for enabling/disabling submit button with correspondence to the pacing and due date, the following pieces of information were required:

- Subsection due date
- Course Pacing
- Grace period

None of these fields is available in DragAndDropXblock. The first notion was to add these fields directly in the Xblock and have them populated when the problem will be created on the Studio. This, however, was a risky move since all the DnD problems in the production would have been affected by the added fields and would have required a re-publish to get populated with the correct data. For the context, the following is an example of how a DnD problem is stored in the mongo:

`{ "_id" : ObjectId("5bf266a6fdf956134ac2565e"), "fields" : { "data" : { "zones" : [ { "uid" : "top", "title" : "The Top Zone", "align" : "center", "height" : 178, "width" : 196, "y" : 30, "x" : 160, "description" : "Use this zone to associate an item with the top layer of the triangle." }, { "uid" : "middle", "title" : "The Middle Zone", "align" : "center", "height" : 138, "width" : 340, "y" : 210, "x" : 86, "description" : "Use this zone to associate an item with the middle layer of the triangle." }, { "uid" : "bottom", "title" : "The Bottom Zone", "align" : "center", "height" : 135, "width" : 485, "y" : 350, "x" : 15, "description" : "Use this zone to associate an item with the bottom layer of the triangle." } ], "items" : [ { "displayName" : "Goes to the top", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Top Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "top" ], "id" : 0 }, { "displayName" : "Goes to the middle", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Middle Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "middle" ], "id" : 1 }, { "displayName" : "Goes to the bottom", "feedback" : { "incorrect" : "No, this item does not belong here. Try again.", "correct" : "Correct! This one belongs to The Bottom Zone." }, "imageURL" : "", "imageDescription" : "", "zones" : [ "bottom" ], "id" : 2 }, { "displayName" : "Goes anywhere", "feedback" : { "incorrect" : "", "correct" : "Of course it goes here! It goes anywhere!" }, "imageURL" : "", "imageDescription" : "", "zones" : [ "top", "middle", "bottom" ], "id" : 3 }, { "displayName" : "I don't belong anywhere", "feedback" : { "incorrect" : "You silly, there are no zones for this one.", "correct" : "" }, "imageURL" : "", "imageDescription" : "", "zones" : [ ], "id" : 4 } ], "targetImgDescription" : "An isosceles triangle with three layers of similar height. It is shown upright, so the widest layer is located at the bottom, and the narrowest layer is located at the top.", "feedback" : { "start" : "Drag the items onto the image above.", "finish" : "Good work! You have completed this drag and drop problem." }, "targetImg" : "/xblock/resource/drag-and-drop-v2/public/img/triangle.png" } }, "edit_info" : { "edited_on" : ISODate("2018-11-19T07:30:46.050Z"), "edited_by" : 2, "original_version" : ObjectId("5bf26695fdf956134ac2565c"), "previous_version" : ObjectId("5bf26695fdf956134ac2565c") }, "block_type" : "drag-and-drop-v2", "schema_version" : 1 }`

This was intriguing as if a DnD problem was viewed from Staff Debug Info on the LMS, it showed the information about the due date, pacing and grace period. This led to viewing how the other problems are stored in the mongo. Here is an example of a random problem stored in the Mongo:

`{ "_id" : ObjectId("5c0625a6fdf9560726d4681b"), "fields" : { "data" : "<problem>\n <multiplechoiceresponse>\n <label>Which of these statements about rods and cones is true?</label>\n <choicegroup type="MultipleChoice">\n <choice correct="true">Rods respond best in a dimly lit environment.</choice>\n <choice correct="false">Rods are for high light conditions; cones are for low light conditions.</choice>\n <choice correct="false">The human retina has more cones than rods.</choice>\n <choice correct="false">Rods come in three types: S, M, and L.</choice>\n </choicegroup>\n <solution>\n <div class="detailed-solution">\n <p>Explanation</p>\n <p>Rods respond best in dim light, whereas cones respond best in bright light and to color. There are around 20 times more rods in the retina than there are cones. Cones come in three flavors: S, M, and L.</p>\n </div>\n </solution>\n </multiplechoiceresponse>\n</problem>\n" }, "edit_info" : { "edited_on" : ISODate("2018-12-04T06:58:46.981Z"), "edited_by" : NumberLong(2), "original_version" : ObjectId("5c0625a6fdf9560726d4681b"), "previous_version" : null }, "block_type" : "problem", "schema_version" : 1 }`

As evident from the data, the regular problem types also don't save the due date, pacing and grace period information. This information is embedded at the run time through the help of Mixins. Looking at the DnD xblock created on the studio/LMS side, it is not DragAndDropXblock, but DragAndDropXblockWithMixins. The addition of the fields to DnDXblock results in the formation of DnDXblockWithMixins, which happens with the [InheritanceMixin](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/inheritance.py#L32). This mixin gets added every Xblock in edx-platform and is responsible for adding such fields to other Xblocks. Initially,  the fix was done in https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/217. However, the added methods were violating DRY principle and they were moved to InheritanceMixin in https://github.com/edx/edx-platform/pull/21148 to allow such methods to be accessible by every Xblock. This PR uses such submission check methods to add subsection due dates checks for DnD in Assessment mode. 

### Sandbox
 - https://educator-4521.sandbox.edx.org/
 - https://studio-educator-4521.sandbox.edx.org/course/course-v1:ArbX+ed2556+2019_T2

### Testing Instructions
 1. Visit the sandbox.
 2. Create a new Drag & Drop problem with **Assessment Mode**
 3. Set Due date in the future. Open the problem in the LMS. Notice that the submit button will be enabled.
 4. Now, set the due date in the past. Try re-submitting it on the LMS. The submit button will be disabled.
         4.1.  Add a graceperiod to see how the submit button state changes with the inclusion of graceperiod.
 5. Change the course pacing to `self-paced`. Visit the LMS again and submit button will be enabled.
 6. Change the pacing back to Instructor-paced, and remove the due date for the subsection.
 7. Visit the LMS. The submit button will be enabled as no due date has been specified.

 - Additional Note: 
For point 4, try to make the submit button enabled using JS debugger. Specifically, the added condition of `!configuration.has_deadline_passed` should be true. Make sure that even after the submit button is enabled, clicking the submit button would result in **409** error in the console. This would verify the submission deadline check enforced on the server.

### Reviewers
 - [x] @bradenmacdonald 
 - [x] @awaisdar001 

### Tests
 - [x] Unit Tests

### Post Review
 - [x] Bump Version
 - [x] Squash & Rebase commits