### PR TITLE
Using ugettext_lazy instead of noop

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -22,6 +22,8 @@ from xblockutils.settings import XBlockWithSettingsMixin, ThemableXBlockMixin
 from .utils import _, DummyTranslationService, FeedbackMessage, FeedbackMessages, ItemStats, StateMigration, Constants
 from .default_data import DEFAULT_DATA
 
+from django.utils.translation import ugettext_lazy as _
+
 
 # Globals ###########################################################
 


### PR DESCRIPTION
Demonstrating how the XBlock is broken when using `ugettext_lazy` instead of `ugettext_noop` (or another dummy function).

Check out this thread on [Open edX Discuss](https://discuss.openedx.org/t/translate-the-default-xblock-data/213). 


### Error Details
![error](https://user-images.githubusercontent.com/645156/62755429-acd71a80-ba7c-11e9-939d-26bf9eb2df32.png)


```
    edx.devstack.studio | Traceback (most recent call last):
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/preview.py", line 326, in get_preview_fragment
    edx.devstack.studio |     fragment = module.render(preview_view, context)
    edx.devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    edx.devstack.studio |     return self.runtime.render(self, view, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1903, in render
    edx.devstack.studio |     return self.__getattr__('render')(block, view_name, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1310, in render
    edx.devstack.studio |     return super(MetricsMixin, self).render(block, view_name, context=context)
    edx.devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 810, in render
    edx.devstack.studio |     frag = view_fn(context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 119, in author_view
    edx.devstack.studio |     self.render_children(context, fragment, can_reorder=True, can_add=True)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/studio_editable.py", line 26, in render_children
    edx.devstack.studio |     rendered_child = child.render(StudioEditableModule.get_preview_view_name(child), context)
    edx.devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    edx.devstack.studio |     return self.runtime.render(self, view, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1903, in render
    edx.devstack.studio |     return self.__getattr__('render')(block, view_name, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1310, in render
    edx.devstack.studio |     return super(MetricsMixin, self).render(block, view_name, context=context)
    edx.devstack.studio |   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 814, in render
    edx.devstack.studio |     updated_frag = self.wrap_xblock(block, view_name, frag, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1262, in wrap_xblock
    edx.devstack.studio |     frag = wrapper(block, view, frag, context)
    edx.devstack.studio |   File "/edx/app/edxapp/edx-platform/openedx/core/lib/xblock_utils/__init__.py", line 146, in wrap_xblock
    edx.devstack.studio |     template_context['js_init_parameters'] = json.dumps(frag.json_init_args).replace("/", r"\/")
    edx.devstack.studio |   File "/usr/lib/python2.7/json/__init__.py", line 244, in dumps
    edx.devstack.studio |     return _default_encoder.encode(obj)
    edx.devstack.studio |   File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    edx.devstack.studio |     chunks = self.iterencode(o, _one_shot=True)
    edx.devstack.studio |   File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    edx.devstack.studio |     return _iterencode(o, 0)
    edx.devstack.studio |   File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    edx.devstack.studio |     raise TypeError(repr(o) + " is not JSON serializable")
    edx.devstack.studio | TypeError: u'Drag and Drop' is not JSON serializable
```