### PR TITLE
Remove undesired whitespace around the editor

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -1,10 +1,12 @@
 .xblock--drag-and-drop--editor {
   width: 100%;
   height: 100%;
+  margin-bottom: 0 !important;  /* Remove an undesired whitespace from Studio */
 }
+
 .modal-window .drag-builder  {
     width: 100%;
-    height: calc(100% - 60px);
+    height: calc(100% - 55px);
     position: absolute;
     overflow-y: scroll;
 }


### PR DESCRIPTION
The Drag and Drop XBlock has a white void that displaces the rest of the editor in Studio:

<kbd>![image](https://user-images.githubusercontent.com/645156/65499185-e4334680-dec5-11e9-8aa3-43d682a0f711.png)</kbd>


### After the Fix
<kbd>![image](https://user-images.githubusercontent.com/645156/65499212-f1503580-dec5-11e9-8ef7-43bbd0fb319c.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/645156/65499377-2e1c2c80-dec6-11e9-8da9-b64f5eb8fa81.png)</kbd>

