### PR TITLE
Solve visual bug with add zone button

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop_edit.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop_edit.css
@@ -385,3 +385,7 @@
     -ms-transform: rotate(45deg);
     transform: rotate(45deg);
 }
+
+.modal-window .modal-content .editor-with-buttons.xblock--drag-and-drop--editor {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
When there are more than 2 zones, the add zone button is not displayed properly.

Before:
![draganddropdanado](https://user-images.githubusercontent.com/22335041/67987252-4ee14b80-fc03-11e9-9de6-9247a72861a2.png)

After:

![draganddropfix](https://user-images.githubusercontent.com/22335041/67987322-72a49180-fc03-11e9-8e28-037c22bd7b29.png)
