### PR TITLE
Render zone title as HTML

### DIFF
--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -262,9 +262,11 @@ function DragAndDropTemplates(configuration) {
                 [
                     h(
                         'p',
-                        { className: className },
+                        {
+                            className: className,
+                            innerHTML: gettext(zone.title)
+                        },
                         [
-                            gettext(zone.title),
                             h('span.sr', gettext(', dropzone'))
                         ]
                     ),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.2.7',
+    version='2.2.8',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/integration/data/test_html_titles_data.json
+++ b/tests/integration/data/test_html_titles_data.json
@@ -1,0 +1,30 @@
+{
+  "zones": [
+    {
+      "width": 200,
+      "title": "Zone <sup>-11</sup>",
+      "height": 100,
+      "y": 200,
+      "x": 100,
+      "uid": "zone-1"
+    }
+  ],
+  "items": [
+    {
+      "displayName": "<b>1</b>",
+      "feedback": {
+        "incorrect": "No <b>1</b>",
+        "correct": "Yes <b>1</b>"
+      },
+      "zone": "zone-1",
+      "imageURL": "",
+      "id": 0
+    }
+  ],
+  "feedback": {
+    "start": "Intro <i>Feed</i>",
+    "finish": "Final <b>Feed</b>"
+  },
+  "targetImg": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4MDAiIGhlaWdodD0iNjAwIiBzdHlsZT0iYmFja2dyb3VuZDogI2VlZjsiPjwvc3ZnPg==",
+  "targetImgDescription": "This describes the target image"
+}

--- a/tests/integration/test_custom_data_render.py
+++ b/tests/integration/test_custom_data_render.py
@@ -24,6 +24,14 @@ class TestCustomDataDragAndDropRendering(BaseIntegrationTest):
         self.assertIn('<i>2</i>', self.get_element_html(items[1]))
         self.assertIn('<span style="color:red">X</span>', self.get_element_html(items[2]))
 
+    def test_html_title_renders_properly(self):
+        """
+        Tests HTML titles are rendered properly
+        """
+        zones = self._get_zones()
+        self.assertEqual(u'Zone\ndroppable\nNo items placed here', zones[0].text)
+        self.assertNotEqual(u'Zone <sup>-1</sup>\ndroppable\nNo items placed here', zones[0].text)
+
     def test_background_image(self):
         bg_image = self.browser.find_element_by_css_selector(".xblock--drag-and-drop .target-img")
         custom_image_url = (
@@ -33,3 +41,27 @@ class TestCustomDataDragAndDropRendering(BaseIntegrationTest):
         custom_image_description = "This describes the target image"
         self.assertEqual(bg_image.get_attribute("src"), custom_image_url)
         self.assertEqual(bg_image.get_attribute("alt"), custom_image_description)
+
+
+class TestZoneTitleAsHTML(BaseIntegrationTest):
+    PAGE_TITLE = 'Drag and Drop v2'
+    PAGE_ID = 'drag_and_drop_v2'
+
+    def setUp(self):
+        super(TestZoneTitleAsHTML, self).setUp()
+
+        scenario_xml = self._get_custom_scenario_xml("data/test_html_titles_data.json")
+        self._add_scenario(self.PAGE_ID, self.PAGE_TITLE, scenario_xml)
+
+        self._page = self.go_to_page(self.PAGE_TITLE)
+
+        header1 = self.browser.find_element_by_css_selector('h1')
+        self.assertEqual(header1.text, 'XBlock: ' + self.PAGE_TITLE)
+
+    def test_html_title_renders_properly(self):
+        """
+        Tests HTML titles are rendered properly
+        """
+        zones = self._get_zones()
+        self.assertEqual(u'Zone\ndroppable\nNo items placed here', zones[0].text)
+        self.assertNotEqual(u'Zone <sup>-1</sup>\ndroppable\nNo items placed here', zones[0].text)


### PR DESCRIPTION
## [PROD-1099](https://openedx.atlassian.net/browse/PROD-1099)

### TLDR

This PR resolves the following issue.

The preview generated within the component editor accepts HTML tags and entities (like, for example, the `<sup>` tag) and displays them properly, but the display within Studio and the LMS shows them as raw text instead.

In the editor, the title is rendered properly as HTML  as in this image 
<img width="428" alt="Screenshot 2020-01-09 at 11 32 39 AM" src="https://user-images.githubusercontent.com/26253150/72043832-0cf41600-32d4-11ea-818b-c21bc9e6f4b0.png">


Whereas on studio page it is rendered as text as in this image 

<img width="428" alt="Screenshot 2020-01-09 at 11 31 57 AM" src="https://user-images.githubusercontent.com/26253150/72043837-12516080-32d4-11ea-8b5e-ed639f5a49c0.png">


### FIX
This is fixed by setting the title as  Innerhtml of `<p>` tag.

### TEST
- Add Drag and Drop block in studio.
- Edit the block by clicking the edit button.
- The modal will open, click continue button on this modal.
- on this page select ` Generate image automatically` checkbox.
- scroll down and in zone definitions fill-up the form and add title ` MW (g &#183; mol<sup>-1</sup>)` and click save .

