### PR TITLE
BB-2681 Fix YTP XBlocks Translations RTL fix

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -889,3 +889,10 @@
         box-shadow: none;
     }
 }
+
+
+/* Fix for rtl in feedback messages*/
+.feedback-content .message::after {
+    display: inline-block;
+}
+


### PR DESCRIPTION
This PR bring is the right-to-left fix from the raccoongang repository

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-2681

**Discussions**: N/A

**Dependencies**: None

**Screenshots**: N/A

**Sandbox URL**: N/A

**Merge deadline**: "None"

**Testing instructions**:

1. install as per usual.
2. in studio add compoenent* problem -> advanced -> drag and drop. It may be a good idea to mare all instructor-input text to for clarity as to what is and is not translated.
3. publish
4. in lms, go to unit, ensure drag and drop is working
5.switch to Arabic (ar)]
6.reload drag and drop problem page, check translations: in particular, submit button, feedback messages, keyboard help, attempts remaining


**Author notes and concerns**:
This is just an scss tweak from right-to-left. The testing instructions are probably superfluous.

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD