### PR TITLE
MCKIN-26101: add drag-and-drop-v2-new entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,15 @@ def package_data(pkg, root_list):
 
 # Main ##############################################################
 
+BLOCKS = [
+    'drag-and-drop-v2 = drag_and_drop_v2:DragAndDropBlock',
+    'drag-and-drop-v2-new = drag_and_drop_v2:DragAndDropBlock',
+]
+
+
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.5',
+    version='2.5.1',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[
@@ -34,7 +40,7 @@ setup(
         'bleach',
     ],
     entry_points={
-        'xblock.v1': 'drag-and-drop-v2 = drag_and_drop_v2:DragAndDropBlock',
+        'xblock.v1': BLOCKS
     },
     package_data=package_data("drag_and_drop_v2", ["static", "templates", "public", "translations"]),
 )


### PR DESCRIPTION
This PR adds `drag-and-drop-v2-new` entry point, so that any instances of the xblock added using this entry point keep working.