### PR TITLE
Fixture to translate two sentences into users language

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -728,9 +728,9 @@ class DragAndDropBlock(
 
         if self.weight > 0:
             if self.attempts_remain:
-                grade_feedback_template = FeedbackMessages.GRADE_FEEDBACK_TPL
+                grade_feedback_template = self.i18n_service.gettext(FeedbackMessages.GRADE_FEEDBACK_TPL)
             else:
-                grade_feedback_template = FeedbackMessages.FINAL_ATTEMPT_TPL
+                grade_feedback_template = self.i18n_service.gettext(FeedbackMessages.FINAL_ATTEMPT_TPL)
 
             feedback_msgs.append(FeedbackMessage(
                 self.i18n_service.gettext(grade_feedback_template).format(score=self.weighted_grade()),


### PR DESCRIPTION
These sentences are marked as translatable by wrapping in the `Dummy gettext replacement`. therefore they are extracted and present in the PO language files. But during the runtime, they are displaying untranslated in English.
I experienced this in an ironwood instance. though I didn't find any relating change trying to fix this issue.