### PR TITLE
refactor: fix instance of DeprecatedEdxPlatformImportWarning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.3.2 (2021-02-12)
+---------------------------
+
+* Fix instance of `DeprecatedEdxPlatformImportWarning`.
+
 Version 2.3.1 (2020-08-04)
 ---------------------------
 

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -911,7 +911,7 @@ class DragAndDropBlock(
             # edX Studio uses a different runtime for 'studio_view' than 'student_view',
             # and the 'studio_view' runtime doesn't provide the replace_urls API.
             try:
-                from static_replace import replace_static_urls  # pylint: disable=import-error
+                from common.djangoapps.static_replace import replace_static_urls  # pylint: disable=import-error
                 url = replace_static_urls(u'"{}"'.format(url), None, course_id=self.runtime.course_id)[1:-1]
             except ImportError:
                 pass

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.1',
+    version='2.3.2',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
The path `static_replace` should instead be
referenced as `common.djangoapps.static_replace`.
The old form will stop working soon.

Bump version to 2.3.2

This upgrade will be [applied to edx-platform here](https://github.com/edx/edx-platform/pull/26235).

_Related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)_