### PR TITLE
DND not loading in studio

### DIFF
--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -27,7 +27,7 @@
                         <select class="problem-mode" aria-describedby="problem-mode-description-{{id_suffix}}">
                             {% for field_value in fields.mode.values %}
                                 <option value="{{ field_value.value }}" {% if self.mode == field_value.value %}selected{% endif %}>
-                                    {% trans field_value.display_name %}
+                                    {{  field_value.display_name }}
                                 </option>
                             {% endfor %}
                         </select>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.2',
+    version='2.3.3',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
### [TNL-8011](https://openedx.atlassian.net/browse/TNL-8011)

## Description:
Drag and drop component is not editable in studio due to some translation issue. Initial investigation shows that `trans`  does not work in loop and cause the error given below. In this PR  I have removed translation from selector to unblock staff.

```
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/deprecation.py", line 94, in __call__
    response = response or self.get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 36, in inner
    response = response_for_exception(request, exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 90, in response_for_exception
    response = handle_uncaught_exception(request, get_resolver(get_urlconf()), sys.exc_info())
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 125, in handle_uncaught_exception
    return debug.technical_500_response(request, *exc_info)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/debug.py", line 91, in technical_500_response
    text = reporter.get_traceback_text()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/debug.py", line 341, in get_traceback_text
    return t.render(c)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 171, in render
    return self._render(context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 163, in _render
    return self.nodelist.render(context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 937, in render
    bit = node.render_annotated(context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 904, in render_annotated
    return self.render(context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 987, in render
    output = self.filter_expression.resolve(context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/base.py", line 698, in resolve
    new_obj = func(obj, *arg_vals)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/template/defaultfilters.py", line 701, in date
    return formats.date_format(value, arg)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/formats.py", line 152, in date_format
    return dateformat.format(value, get_format(format or 'DATE_FORMAT', use_l10n=use_l10n))
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/dateformat.py", line 361, in format
    return df.format(format_string)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/dateformat.py", line 38, in format
    pieces.append(str(getattr(self, piece)()))
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/dateformat.py", line 287, in r
    return self.format('D, j M Y H:i:s O')
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/dateformat.py", line 38, in format
    pieces.append(str(getattr(self, piece)()))
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 156, in __text_cast
    return func(*self.__args, **self.__kw)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/translation/__init__.py", line 79, in gettext
    return _trans.gettext(message)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/translation/trans_real.py", line 357, in gettext
    result = translation_object.gettext(eol_message)
  File "/usr/lib/python3.8/gettext.py", line 497, in gettext
    return self._fallback.gettext(message)
  File "/usr/lib/python3.8/gettext.py", line 497, in gettext
    return self._fallback.gettext(message)
  File "/usr/lib/python3.8/gettext.py", line 497, in gettext
    return self._fallback.gettext(message)
  [Previous line repeated 863 more times]
  File "/usr/lib/python3.8/gettext.py", line 493, in gettext
    missing = object()
RecursionError: maximum recursion depth exceeded while calling a Python object

```


### Notes: 
https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/266
https://code.djangoproject.com/ticket/23441#no1