### PR TITLE
fix: remove tox-battery from requirements and update tox

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ asgiref==3.7.2
     # via django
 bleach[css]==6.1.0
     # via -r requirements/base.in
-boto3==1.33.6
+boto3==1.33.10
     # via fs-s3fs
-botocore==1.33.6
+botocore==1.33.10
     # via
     #   boto3
     #   s3transfer

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -14,26 +20,19 @@ packaging==23.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   tox
     #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.in
 virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,11 +29,11 @@ bleach[css]==6.1.0
     # via
     #   -r requirements/quality.txt
     #   bleach
-boto3==1.33.6
+boto3==1.33.10
     # via
     #   -r requirements/quality.txt
     #   fs-s3fs
-botocore==1.33.6
+botocore==1.33.10
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -42,14 +42,20 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   requests
 chardet==5.2.0
     # via
+    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   binaryornot
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
@@ -71,6 +77,10 @@ code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 cookiecutter==2.5.0
     # via
     #   -r requirements/quality.txt
@@ -199,9 +209,10 @@ packaging==23.2
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
-path==16.7.1
+path==16.9.0
     # via
     #   -r requirements/quality.txt
     #   edx-i18n-tools
@@ -211,10 +222,10 @@ pbr==6.0.0
     #   stevedore
 pip-tools==7.3.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -226,10 +237,6 @@ polib==1.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-i18n-tools
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
 pygments==2.17.2
@@ -261,6 +268,10 @@ pypng==0.20220715.0
     # via
     #   -r requirements/quality.txt
     #   xblock-sdk
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -317,7 +328,6 @@ simplejson==3.19.2
     #   xblock-sdk
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   astroid
     #   bleach
@@ -325,7 +335,6 @@ six==1.16.0
     #   fs
     #   fs-s3fs
     #   python-dateutil
-    #   tox
 sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt
@@ -350,14 +359,11 @@ tomli==2.0.1
     #   build
     #   coverage
     #   pip-tools
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.txt
 types-python-dateutil==2.8.19.14
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,11 +28,11 @@ bleach[css]==6.1.0
     # via
     #   -r requirements/test.txt
     #   bleach
-boto3==1.33.6
+boto3==1.33.10
     # via
     #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.33.6
+botocore==1.33.10
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -167,7 +167,7 @@ packaging==23.2
     # via
     #   -r requirements/test.txt
     #   pytest
-path==16.7.1
+path==16.9.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,11 +20,11 @@ bleach[css]==6.1.0
     # via
     #   -r requirements/base.txt
     #   bleach
-boto3==1.33.6
+boto3==1.33.10
     # via
     #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.33.6
+botocore==1.33.10
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -118,7 +118,7 @@ openedx-django-pyfs==3.4.0
     #   xblock
 packaging==23.2
     # via pytest
-path==16.7.1
+path==16.9.0
     # via edx-i18n-tools
 pluggy==1.3.0
     # via pytest


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements since it is not needed for `toxv4` anymore.
- Updated `tox` to `v4`.