### PR TITLE
fix(js): wait for virtualDom before initializing block

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ Drag and Drop XBlock changelog
 Unreleased
 ---------------------------
 
+Version 5.0.6 (2026-04-29)
+--------------------------
+
+* Wait for `virtualDom` before initializing block.
+
 Version 5.0.5 (2026-03-23)
 --------------------------
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "5.0.5"
+__version__ = "5.0.6"

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1,4 +1,4 @@
-function DragAndDropTemplates(configuration) {
+function DragAndDropTemplates(configuration, virtualDomLib) {
     "use strict";
 
     var gettext;
@@ -32,7 +32,7 @@ function DragAndDropTemplates(configuration) {
         gettext = function(string) { return string; };
         ngettext = function(strA, strB, n) { return n == 1 ? strA : strB; };
     }
-    var h = virtualDom.h;
+    var h = virtualDomLib.h;
 
     var isMobileScreen = function() {
         return window.matchMedia('screen and (max-width: 480px)').matches;
@@ -785,7 +785,7 @@ function DragAndDropBlock(runtime, element, configuration) {
         gettext = function(string) { return string; };
     }
 
-    var renderView = DragAndDropTemplates(configuration);
+    var renderView = null;
 
     var $element = $(element);
 
@@ -797,7 +797,8 @@ function DragAndDropBlock(runtime, element, configuration) {
     var bgImgNaturalWidth = undefined;  // pixel width of the background image (when not scaled)
     var containerMaxWidth = null;  // measured and set after first render
     var fixedHeaderHeight = 0; // measured in checkForFixedHeader
-    var __vdom = virtualDom.h();  // blank virtual DOM
+    var __vdom = null;
+    var virtualDomLib = window.virtualDom || (typeof virtualDom !== 'undefined' ? virtualDom : null);
 
     // Event string size limit.
     var MAX_LENGTH = 255;
@@ -1212,8 +1213,8 @@ function DragAndDropBlock(runtime, element, configuration) {
 
     var updateDOM = function() {
         var new_vdom = render(state);
-        var patches = virtualDom.diff(__vdom, new_vdom);
-        root = virtualDom.patch(root, patches);
+        var patches = virtualDomLib.diff(__vdom, new_vdom);
+        root = virtualDomLib.patch(root, patches);
         $root = $(root);
         __vdom = new_vdom;
     };
@@ -2113,5 +2114,41 @@ function DragAndDropBlock(runtime, element, configuration) {
         });
     };
 
-    init();
+    /**
+     * Wait until virtual-dom library available, then continue normal block initialization.
+     *
+     * Why: in some deployments cached `drag_and_drop.js` can execute before
+     * `virtual-dom-1.3.0.min.js` has finished loading, which causes
+     * `ReferenceError: virtualDom is not defined` on first access.
+     *
+     * How:
+     * - Retry every 25ms.
+     * - Stop after 5s and show generic load error message.
+     * - Once available, create renderer + blank vdom root, then call `init()`.
+     *
+     * @param {number} elapsedMs Milliseconds spent waiting so far.
+     */
+    var waitForVirtualDomAndInit = function(elapsedMs) {
+        if (!virtualDomLib) {
+            virtualDomLib = window.virtualDom || (typeof virtualDom !== 'undefined' ? virtualDom : null);
+        }
+
+        if (virtualDomLib) {
+            renderView = DragAndDropTemplates(configuration, virtualDomLib);
+            __vdom = virtualDomLib.h();  // blank virtual DOM
+            init();
+            return;
+        }
+
+        if (elapsedMs >= 5000) {
+            $root.text(gettext("An error occurred. Unable to load drag and drop problem."));
+            return;
+        }
+
+        setTimeout(function() {
+            waitForVirtualDomAndInit(elapsedMs + 25);
+        }, 25);
+    };
+
+    waitForVirtualDomAndInit(0);
 }


### PR DESCRIPTION
## Description

Fix race condition where `drag_and_drop.js` may execute before `virtual-dom-1.3.0.min.js` loads, causing:
`ReferenceError: virtualDom is not defined`.

This PR changes DnDv2 frontend init flow to wait for virtual-dom before first access.

- `DragAndDropTemplates` now receives resolved virtual-dom instance instead of reading global directly.
- `DragAndDropBlock` defers renderer/vdom initialization until library is available.
- Added `waitForVirtualDomAndInit(elapsedMs)` with:
  - 25ms retry interval
  - 5s timeout
  - fallback message if dependency never appears

## Supporting information

- Related to: https://github.com/openedx/frontend-app-authoring/issues/1749
- `Private-ref`: https://tasks.opencraft.com/browse/FAL-4331

## Testing instructions

1. Open learner view with a Drag and Drop v2 block.
2. Confirm block initializes and renders without console error.
3. Verify browser console has no `virtualDom is not defined` during page load.

## Deadline

None.

