### PR TITLE
feat: include item metadata in drag-and-drop report state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,12 @@ Drag and Drop XBlock changelog
 ==============================
 
 Unreleased
-Version 5.0.7 (2026-07-23)
 --------------------------
 
-* Added `displayName`, `feedback`, `correct` and `imageURL` to the learner item state returned by `student_view_user_state` and stored in `item_state`.
+Version 5.1.0 (2026-07-23)
+--------------------------
+
+* Added `display_name`, `feedback` and `image_url` to the learner item state returned by `student_view_user_state` and stored in `item_state`.
 
 Version 5.0.6 (2026-04-29)
 --------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@ Drag and Drop XBlock changelog
 ==============================
 
 Unreleased
----------------------------
+Version 5.0.7 (2026-07-23)
+--------------------------
+
+* Added `displayName`, `feedback`, `correct` and `imageURL` to the learner item state returned by `student_view_user_state` and stored in `item_state`.
 
 Version 5.0.6 (2026-04-29)
 --------------------------

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "5.0.7"
+__version__ = "5.1.0"

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "5.0.6"
+__version__ = "5.0.7"

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -977,10 +977,11 @@ class DragAndDropBlock(
                 raise JsonHandlerError(400, "Item zone data invalid.")
 
     @staticmethod
-    def _make_state_from_attempt(attempt, correct, item={}):
+    def _make_state_from_attempt(attempt, correct, item=None):
         """
         Converts "attempt" data coming from browser into "state" entry stored in item_state
         """
+        item = item or {}
         return {
             'zone': attempt['zone'],
             'correct': correct,

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -985,8 +985,8 @@ class DragAndDropBlock(
         return {
             'zone': attempt['zone'],
             'correct': correct,
-            'imageURL': item.get('imageURL'),
-            'displayName': item.get('displayName'),
+            'image_url': item.get('imageURL'),
+            'display_name': item.get('displayName'),
             'feedback': item.get('feedback', {})
         }
 

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -930,7 +930,7 @@ class DragAndDropBlock(
 
         is_correct = self._is_attempt_correct(item_attempt)  # Student placed item in a correct zone
         if is_correct:  # In standard mode state is only updated when attempt is correct
-            self.item_state[str(item['id'])] = self._make_state_from_attempt(item_attempt, is_correct)
+            self.item_state[str(item['id'])] = self._make_state_from_attempt(item_attempt, is_correct, item)
 
         self._mark_complete_and_publish_grade()  # must happen before _get_feedback
         self._publish_item_dropped_event(item_attempt, is_correct)
@@ -961,7 +961,7 @@ class DragAndDropBlock(
             self._publish_item_to_bank_event(item['id'], is_correct)
         else:
             # State is always updated in assessment mode to store intermediate item positions
-            self.item_state[str(item['id'])] = self._make_state_from_attempt(item_attempt, is_correct)
+            self.item_state[str(item['id'])] = self._make_state_from_attempt(item_attempt, is_correct, item)
             self._publish_item_dropped_event(item_attempt, is_correct)
 
         return {}
@@ -977,13 +977,16 @@ class DragAndDropBlock(
                 raise JsonHandlerError(400, "Item zone data invalid.")
 
     @staticmethod
-    def _make_state_from_attempt(attempt, correct):
+    def _make_state_from_attempt(attempt, correct, item={}):
         """
         Converts "attempt" data coming from browser into "state" entry stored in item_state
         """
         return {
             'zone': attempt['zone'],
-            'correct': correct
+            'correct': correct,
+            'imageURL': item.get('imageURL'),
+            'displayName': item.get('displayName'),
+            'feedback': item.get('feedback', {})
         }
 
     def _mark_complete_and_publish_grade(self):

--- a/tests/unit/test_assessment_mode.py
+++ b/tests/unit/test_assessment_mode.py
@@ -60,7 +60,13 @@ class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
 
             self.assertEqual(res, {})
 
-            expected_item_state = {'zone': zone_id, 'correct': True}
+            expected_item_state = {
+                "zone": zone_id,
+                "correct": True,
+                "imageURL": "",
+                "displayName": str(item_id + 1),   # or the expected display name
+                "feedback": self.FEEDBACK[item_id],
+            }
 
             self.assertIn(str(item_id), self.block.item_state)
             self.assertEqual(self.block.item_state[str(item_id)], expected_item_state)

--- a/tests/unit/test_assessment_mode.py
+++ b/tests/unit/test_assessment_mode.py
@@ -63,8 +63,8 @@ class AssessmentModeFixture(BaseDragAndDropAjaxFixture):
             expected_item_state = {
                 "zone": zone_id,
                 "correct": True,
-                "imageURL": "",
-                "displayName": str(item_id + 1),   # or the expected display name
+                "image_url": "",
+                "display_name": str(item_id + 1),   # or the expected display name
                 "feedback": self.FEEDBACK[item_id],
             }
 

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -258,42 +258,42 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             '0': {
                 'correct': True,
                 'zone': TOP_ZONE_ID,
-                'displayName': 'Goes to the top',
+                'display_name': 'Goes to the top',
                 'feedback': {
                     'correct': 'Correct! This one belongs to The Top Zone.',
                     'incorrect': 'No, this item does not belong here. Try again.',
                 },
-                'imageURL': '',
+                'image_url': '',
             },
             '1': {
                 'correct': True,
                 'zone': MIDDLE_ZONE_ID,
-                'displayName': 'Goes to the middle',
+                'display_name': 'Goes to the middle',
                 'feedback': {
                     'correct': 'Correct! This one belongs to The Middle Zone.',
                     'incorrect': 'No, this item does not belong here. Try again.',
                 },
-                'imageURL': '',
+                'image_url': '',
             },
             '2': {
                 'correct': True,
                 'zone': BOTTOM_ZONE_ID,
-                'displayName': 'Goes to the bottom',
+                'display_name': 'Goes to the bottom',
                 'feedback': {
                     'correct': 'Correct! This one belongs to The Bottom Zone.',
                     'incorrect': 'No, this item does not belong here. Try again.',
                 },
-                'imageURL': '',
+                'image_url': '',
             },
             '3': {
                 'correct': True,
                 'zone': MIDDLE_ZONE_ID,
-                'displayName': 'Goes anywhere',
+                'display_name': 'Goes anywhere',
                 'feedback': {
                     'correct': 'Of course it goes here! It goes anywhere!',
                     'incorrect': '',
                 },
-                'imageURL': '',
+                'image_url': '',
             },
         })
         self.assertEqual(self.call_handler('student_view_user_state'), {
@@ -301,42 +301,42 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
                 '0': {
                     'correct': True,
                     'zone': TOP_ZONE_ID,
-                    'displayName': 'Goes to the top',
+                    'display_name': 'Goes to the top',
                     'feedback': {
                         'correct': 'Correct! This one belongs to The Top Zone.',
                         'incorrect': 'No, this item does not belong here. Try again.',
                     },
-                    'imageURL': '',
+                    'image_url': '',
                 },
                 '1': {
                     'correct': True,
                     'zone': MIDDLE_ZONE_ID,
-                    'displayName': 'Goes to the middle',
+                    'display_name': 'Goes to the middle',
                     'feedback': {
                         'correct': 'Correct! This one belongs to The Middle Zone.',
                         'incorrect': 'No, this item does not belong here. Try again.',
                     },
-                    'imageURL': '',
+                    'image_url': '',
                 },
                 '2': {
                     'correct': True,
                     'zone': BOTTOM_ZONE_ID,
-                    'displayName': 'Goes to the bottom',
+                    'display_name': 'Goes to the bottom',
                     'feedback': {
                         'correct': 'Correct! This one belongs to The Bottom Zone.',
                         'incorrect': 'No, this item does not belong here. Try again.',
                     },
-                    'imageURL': '',
+                    'image_url': '',
                 },
                 '3': {
                     'correct': True,
                     'zone': MIDDLE_ZONE_ID,
-                    'displayName': 'Goes anywhere',
+                    'display_name': 'Goes anywhere',
                     'feedback': {
                         'correct': 'Of course it goes here! It goes anywhere!',
                         'incorrect': '',
                     },
-                    'imageURL': '',
+                    'image_url': '',
                 },
             },
             'finished': True,

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -255,26 +255,100 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
         # Check the result:
         self.assertTrue(self.block.completed)
         self.assertEqual(self.block.item_state, {
-            '0': {'correct': True, 'zone': TOP_ZONE_ID},
-            '1': {'correct': True, 'zone': MIDDLE_ZONE_ID},
-            '2': {'correct': True, 'zone': BOTTOM_ZONE_ID},
-            '3': {'correct': True, "zone": MIDDLE_ZONE_ID},
+            '0': {
+                'correct': True,
+                'zone': TOP_ZONE_ID,
+                'displayName': 'Goes to the top',
+                'feedback': {
+                    'correct': 'Correct! This one belongs to The Top Zone.',
+                    'incorrect': 'No, this item does not belong here. Try again.',
+                },
+                'imageURL': '',
+            },
+            '1': {
+                'correct': True,
+                'zone': MIDDLE_ZONE_ID,
+                'displayName': 'Goes to the middle',
+                'feedback': {
+                    'correct': 'Correct! This one belongs to The Middle Zone.',
+                    'incorrect': 'No, this item does not belong here. Try again.',
+                },
+                'imageURL': '',
+            },
+            '2': {
+                'correct': True,
+                'zone': BOTTOM_ZONE_ID,
+                'displayName': 'Goes to the bottom',
+                'feedback': {
+                    'correct': 'Correct! This one belongs to The Bottom Zone.',
+                    'incorrect': 'No, this item does not belong here. Try again.',
+                },
+                'imageURL': '',
+            },
+            '3': {
+                'correct': True,
+                'zone': MIDDLE_ZONE_ID,
+                'displayName': 'Goes anywhere',
+                'feedback': {
+                    'correct': 'Of course it goes here! It goes anywhere!',
+                    'incorrect': '',
+                },
+                'imageURL': '',
+            },
         })
         self.assertEqual(self.call_handler('student_view_user_state'), {
             'items': {
-                '0': {'correct': True, 'zone': TOP_ZONE_ID},
-                '1': {'correct': True, 'zone': MIDDLE_ZONE_ID},
-                '2': {'correct': True, 'zone': BOTTOM_ZONE_ID},
-                '3': {'correct': True, "zone": MIDDLE_ZONE_ID},
+                '0': {
+                    'correct': True,
+                    'zone': TOP_ZONE_ID,
+                    'displayName': 'Goes to the top',
+                    'feedback': {
+                        'correct': 'Correct! This one belongs to The Top Zone.',
+                        'incorrect': 'No, this item does not belong here. Try again.',
+                    },
+                    'imageURL': '',
+                },
+                '1': {
+                    'correct': True,
+                    'zone': MIDDLE_ZONE_ID,
+                    'displayName': 'Goes to the middle',
+                    'feedback': {
+                        'correct': 'Correct! This one belongs to The Middle Zone.',
+                        'incorrect': 'No, this item does not belong here. Try again.',
+                    },
+                    'imageURL': '',
+                },
+                '2': {
+                    'correct': True,
+                    'zone': BOTTOM_ZONE_ID,
+                    'displayName': 'Goes to the bottom',
+                    'feedback': {
+                        'correct': 'Correct! This one belongs to The Bottom Zone.',
+                        'incorrect': 'No, this item does not belong here. Try again.',
+                    },
+                    'imageURL': '',
+                },
+                '3': {
+                    'correct': True,
+                    'zone': MIDDLE_ZONE_ID,
+                    'displayName': 'Goes anywhere',
+                    'feedback': {
+                        'correct': 'Of course it goes here! It goes anywhere!',
+                        'incorrect': '',
+                    },
+                    'imageURL': '',
+                },
             },
             'finished': True,
-            "attempts": 0,
-            "grade": 1,
+            'attempts': 0,
+            'grade': 1,
             'overall_feedback': [
-                {"message": FINISH_FEEDBACK, "message_class": FeedbackMessages.MessageClasses.FINAL_FEEDBACK}
+                {
+                    'message': FINISH_FEEDBACK,
+                    'message_class': FeedbackMessages.MessageClasses.FINAL_FEEDBACK,
+                }
             ],
         })
-
         # Reset to initial conditions
         self.call_handler('reset', {})
         self.assertTrue(self.block.completed)

--- a/tests/unit/test_standard_mode.py
+++ b/tests/unit/test_standard_mode.py
@@ -247,9 +247,9 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
                 "0": {
                     "correct": True,
                     "zone": self.ZONE_1,
-                    "displayName": self.block.item_state["0"]["displayName"],
+                    "display_name": self.block.item_state["0"]["display_name"],
                     "feedback": self.FEEDBACK[0],
-                    "imageURL": "",
+                    "image_url": "",
                 },
             },
             "finished": False,
@@ -279,16 +279,16 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
                 "0": {
                     "correct": True,
                     "zone": self.ZONE_1,
-                    "displayName": self.block.item_state["0"]["displayName"],
+                    "display_name": self.block.item_state["0"]["display_name"],
                     "feedback": self.FEEDBACK[0],
-                    "imageURL": "",
+                    "image_url": "",
                 },
                 "1": {
                     "correct": True,
                     "zone": self.ZONE_2,
-                    "displayName": self.block.item_state["1"]["displayName"],
+                    "display_name": self.block.item_state["1"]["display_name"],
                     "feedback": self.FEEDBACK[1],
-                    "imageURL": "",
+                    "image_url": "",
                 }
             },
             "finished": True,

--- a/tests/unit/test_standard_mode.py
+++ b/tests/unit/test_standard_mode.py
@@ -244,7 +244,13 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
         expected_grade = self.block.weight * 3 / 4.0
         expected_state = {
             "items": {
-                "0": {"correct": True, "zone": self.ZONE_1}
+                "0": {
+                    "correct": True,
+                    "zone": self.ZONE_1,
+                    "displayName": self.block.item_state["0"]["displayName"],
+                    "feedback": self.FEEDBACK[0],
+                    "imageURL": "",
+                },
             },
             "finished": False,
             "attempts": 0,
@@ -270,8 +276,20 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
 
         expected_state = {
             "items": {
-                "0": {"correct": True, "zone": self.ZONE_1},
-                "1": {"correct": True, "zone": self.ZONE_2}
+                "0": {
+                    "correct": True,
+                    "zone": self.ZONE_1,
+                    "displayName": self.block.item_state["0"]["displayName"],
+                    "feedback": self.FEEDBACK[0],
+                    "imageURL": "",
+                },
+                "1": {
+                    "correct": True,
+                    "zone": self.ZONE_2,
+                    "displayName": self.block.item_state["1"]["displayName"],
+                    "feedback": self.FEEDBACK[1],
+                    "imageURL": "",
+                }
             },
             "finished": True,
             "attempts": 0,


### PR DESCRIPTION
## Description

Enhance the Drag-and-Drop XBlock report data by including additional item
metadata within `item_state`.

Currently, reports only expose zone mappings for each item, which limits the
ability to understand learner interactions and outcomes when analyzing report
data.

This change extends `item_state` to include relevant item metadata such as:

- `displayName`
- `feedback`
- `correct`
- `imageURL`

Example:

```json{
  "item_state": {
    "0": {
      "zone": "top",
      "displayName": "Goes to the top",
      "feedback": "Correct placement",
      "correct": true,
      "imageURL": "/static/example.png"
    }
  }
}'''